### PR TITLE
Fix imports in tests

### DIFF
--- a/tests/test_imports.py
+++ b/tests/test_imports.py
@@ -1,10 +1,11 @@
 import importlib
 
 modules = [
-    'app.api.routers.books',
-    'app.api.routers.profile_actions',
-    'app.api.routers.users',
-    'app.models.author',
+    'pyskoob.auth',
+    'pyskoob.books',
+    'pyskoob.users',
+    'pyskoob.profile',
+    'pyskoob.models.author',
 ]
 
 for mod in modules:


### PR DESCRIPTION
## Summary
- update `tests/test_imports.py` to import modules from `pyskoob`
- remove leftover inline comments

## Testing
- `pip install -e .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688a9fa9ee3c832982c64057901f0ca4

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated test imports to use the `pyskoob` namespace instead of the `app` namespace.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->