### PR TITLE
Apply autopep8 formatting

### DIFF
--- a/pyskoob/__init__.py
+++ b/pyskoob/__init__.py
@@ -1,2 +1,1 @@
 """Public API for the PySkoob package."""
-

--- a/pyskoob/auth.py
+++ b/pyskoob/auth.py
@@ -86,7 +86,7 @@ class AuthService(BaseSkoobService):
         data = {
             "data[Usuario][email]": email,
             "data[Usuario][senha]": password,
-            "data[Login][automatico]": True
+            "data[Login][automatico]": True,
         }
 
         response = self.client.post(url, data=data)
@@ -98,8 +98,14 @@ class AuthService(BaseSkoobService):
             logger.error("Login response was not valid JSON")
             raise ConnectionError("Invalid response format") from exc
         if not json_data.get("success", False):
-            logger.error("Login failed: %s", json_data.get("message", "Unknown error"))
-            raise ConnectionError("Failed to login: {}".format(json_data.get("message", "Unknown error")))
+            logger.error(
+                "Login failed: %s", json_data.get("message", "Unknown error")
+            )
+            raise ConnectionError(
+                "Failed to login: {}".format(
+                    json_data.get("message", "Unknown error")
+                )
+            )
 
         self._is_logged_in = True
         user = self.get_my_info()
@@ -132,14 +138,19 @@ class AuthService(BaseSkoobService):
 
         json_data = response.json()
         if not json_data.get("success"):
-            logger.error("Failed to retrieve user information. The session token might be invalid.")
+            logger.error(
+                "Failed to retrieve user information. "
+                "The session token might be invalid."
+            )
             raise ConnectionError(
                 "Failed to retrieve user information. "
                 "The session token might be invalid."
             )
 
         user_data = json_data["response"]
-        user_data["profile_url"] = self.base_url + user_data["url"]  # patch field for alias
+        user_data["profile_url"] = (
+            self.base_url + user_data["url"]
+        )  # patch field for alias
         user = User.model_validate(user_data)
         logger.info(f"Successfully retrieved user: '{user.name}'")
         return user
@@ -162,6 +173,7 @@ class AuthService(BaseSkoobService):
         if not self._is_logged_in:
             logger.warning("Validation failed: User is not logged in.")
             raise PermissionError(
-                "User is not logged in. Please call 'login_with_cookies' first."
+                "User is not logged in. "
+                "Please call 'login_with_cookies' first."
             )
         logger.debug("Validation successful: User is logged in.")

--- a/pyskoob/books.py
+++ b/pyskoob/books.py
@@ -32,11 +32,12 @@ class BookService(BaseSkoobService):
     independently from authentication, but other services may combine it
     with :class:`AuthService` to operate on the authenticated user's data.
     """
+
     def search(
         self,
         query: str,
         search_by: BookSearch = BookSearch.TITLE,
-        page: int = 1
+        page: int = 1,
     ) -> Pagination[BookSearchResult]:
         """
         Searches for books by query and type.
@@ -46,7 +47,8 @@ class BookService(BaseSkoobService):
         query : str
             The search query string.
         search_by : BookSearch, optional
-            The type of search (title, author, etc.), by default BookSearch.TITLE.
+            The type of search (title, author, etc.), by default
+            ``BookSearch.TITLE``.
         page : int, optional
             The page number for pagination, by default 1.
 
@@ -65,8 +67,13 @@ class BookService(BaseSkoobService):
         >>> service.search("Duna").results[0].title
         'Duna'
         """
-        url = f"{self.base_url}/livro/lista/busca:{query}/tipo:{search_by.value}/mpage:{page}"
-        logger.info(f"Searching for books with query: '{query}' on page {page}")
+        url = (
+            f"{self.base_url}/livro/lista/busca:{query}/"
+            f"tipo:{search_by.value}/mpage:{page}"
+        )
+        logger.info(
+            f"Searching for books with query: '{query}' on page {page}"
+        )
         try:
             response = self.client.get(url)
             response.raise_for_status()
@@ -75,26 +82,40 @@ class BookService(BaseSkoobService):
             limit = 30
             results: list[BookSearchResult | None] = [
                 self._parse_search_result(book_div)
-                for book_div in safe_find_all(soup, 'div', {'class': 'box_lista_busca_vertical'})
+                for book_div in safe_find_all(
+                    soup, "div", {"class": "box_lista_busca_vertical"}
+                )
             ]
             cleaned_results: list[BookSearchResult] = [i for i in results if i]
 
             total_results = self._extract_total_results(soup)
             next_page_link = True if page * limit < total_results else False
         except (AttributeError, ValueError, IndexError, TypeError) as e:
-            logger.error(f"Failed to parse book search results: {e}", exc_info=True)
+            logger.error(
+                f"Failed to parse book search results: {e}", exc_info=True
+            )
             raise ParsingError("Failed to parse book search results.") from e
         except Exception as e:
-            logger.error(f"An unexpected error occurred during book search: {e}", exc_info=True)
-            raise ParsingError("An unexpected error occurred during book search.") from e
+            logger.error(
+                f"An unexpected error occurred during book search: {e}",
+                exc_info=True,
+            )
+            raise ParsingError(
+                "An unexpected error occurred during book search."
+            ) from e
 
-        logger.info(f"Found {len(results)} books on page {page}, total {total_results} results.")
+        logger.info(
+            "Found %s books on page %s, total %s results.",
+            len(results),
+            page,
+            total_results,
+        )
         return Pagination[BookSearchResult](
             results=cleaned_results,
             limit=30,
             page=page,
             total=total_results,
-            has_next_page=next_page_link
+            has_next_page=next_page_link,
         )
 
     def get_by_id(self, edition_id: int) -> Book:
@@ -130,25 +151,36 @@ class BookService(BaseSkoobService):
             response.raise_for_status()
             json_data = response.json().get("response")
             if not json_data:
-                cod_description = response.json().get('cod_description', 'No description provided.')
-                error_msg = f"No data found for edition_id {edition_id}. Description: {cod_description}"
+                cod_description = response.json().get(
+                    "cod_description", "No description provided."
+                )
+                error_msg = (
+                    f"No data found for edition_id {edition_id}. "
+                    f"Description: {cod_description}"
+                )
                 logger.warning(error_msg)
                 raise FileNotFoundError(error_msg)
             self._clean_book_json_data(json_data)
             book = Book.model_validate(json_data)
-            logger.info(f"Successfully retrieved book: '{book.title}' (Edition ID: {edition_id})")
+            logger.info(
+                "Successfully retrieved book: '%s' (Edition ID: %s)",
+                book.title,
+                edition_id,
+            )
             return book
         except FileNotFoundError:
             raise
         except Exception as e:
-            logger.error(f"Error retrieving book for edition_id {edition_id}: {e}", exc_info=True)
-            raise ParsingError(f"Failed to retrieve book for edition_id {edition_id}.") from e
+            logger.error(
+                f"Error retrieving book for edition_id {edition_id}: {e}",
+                exc_info=True,
+            )
+            raise ParsingError(
+                f"Failed to retrieve book for edition_id {edition_id}."
+            ) from e
 
     def get_reviews(
-        self,
-        book_id: int,
-        edition_id: int | None = None,
-        page: int = 1
+        self, book_id: int, edition_id: int | None = None, page: int = 1
     ) -> Pagination[BookReview]:
         """
         Retrieves reviews for a book.
@@ -177,9 +209,9 @@ class BookService(BaseSkoobService):
         >>> service.get_reviews(123).results
         [...]
         """
-        url = f'{self.base_url}/livro/resenhas/{book_id}/mpage:{page}/limit:50'
+        url = f"{self.base_url}/livro/resenhas/{book_id}/mpage:{page}/limit:50"
         if edition_id:
-            url += f'/edition:{edition_id}'
+            url += f"/edition:{edition_id}"
         logger.info(f"Getting reviews for book_id: {book_id}, page: {page}")
         try:
             response = self.client.get(url)
@@ -188,25 +220,34 @@ class BookService(BaseSkoobService):
             if edition_id is None:
                 edition_id = self._extract_edition_id_from_reviews_page(soup)
             book_reviews = [
-                review for review in (
+                review
+                for review in (
                     self._parse_review(r, book_id, edition_id)
-                    for r in safe_find_all(soup, 'div', {'id': re.compile(r'resenha\d+')})
-                ) if review is not None
+                    for r in safe_find_all(
+                        soup, "div", {"id": re.compile(r"resenha\d+")}
+                    )
+                )
+                if review is not None
             ]
-            next_page_link = safe_find(soup, 'a', {'class': 'proximo'})
+            next_page_link = safe_find(soup, "a", {"class": "proximo"})
         except (AttributeError, ValueError, IndexError, TypeError) as e:
             logger.error(f"Failed to parse book reviews: {e}", exc_info=True)
             raise ParsingError("Failed to parse book reviews.") from e
         except Exception as e:
-            logger.error(f"An unexpected error occurred during review fetching: {e}", exc_info=True)
-            raise ParsingError("An unexpected error occurred during review fetching.") from e
+            logger.error(
+                f"An unexpected error occurred during review fetching: {e}",
+                exc_info=True,
+            )
+            raise ParsingError(
+                "An unexpected error occurred during review fetching."
+            ) from e
         logger.info(f"Found {len(book_reviews)} reviews on page {page}.")
         return Pagination[BookReview](
             results=book_reviews,
             limit=50,
             page=page,
             total=len(book_reviews),
-            has_next_page=next_page_link is not None
+            has_next_page=next_page_link is not None,
         )
 
     def get_users_by_status(
@@ -215,7 +256,7 @@ class BookService(BaseSkoobService):
         status: BookUserStatus,
         edition_id: int | None = None,
         limit: int = 500,
-        page: int = 1
+        page: int = 1,
     ) -> Pagination[int]:
         """
         Retrieves users who have a book with a specific status.
@@ -248,29 +289,49 @@ class BookService(BaseSkoobService):
         >>> service.get_users_by_status(1, BookUserStatus.READERS).results[:3]
         [1, 2, 3]
         """
-        url = f"{self.base_url}/livro/leitores/{status.value}/{book_id}/limit:{limit}/page:{page}"
+        url = (
+            f"{self.base_url}/livro/leitores/{status.value}/{book_id}/"
+            f"limit:{limit}/page:{page}"
+        )
         if edition_id:
             url += f"/edition:{edition_id}"
-        logger.info(f"Getting users for book_id: {book_id} with status '{status.value}' on page {page}")
+        logger.info(
+            "Getting users for book_id: %s with status '%s' on page %s",
+            book_id,
+            status.value,
+            page,
+        )
         try:
             response = self.client.get(url)
             response.raise_for_status()
             soup = self.parse_html(response.text)
             users_id = self._extract_user_ids_from_html(soup)
-            next_page_link = safe_find(soup, 'a', {'class': 'proximo'})
+            next_page_link = safe_find(soup, "a", {"class": "proximo"})
         except (AttributeError, ValueError, IndexError, TypeError) as e:
-            logger.error(f"Failed to parse users by status: {e}", exc_info=True)
+            logger.error(
+                f"Failed to parse users by status: {e}", exc_info=True
+            )
             raise ParsingError("Failed to parse users by status.") from e
         except Exception as e:
-            logger.error(f"An unexpected error occurred during user status fetching: {e}", exc_info=True)
-            raise ParsingError("An unexpected error occurred during user status fetching.") from e
-        logger.info(f"Found {len(users_id)} users on page {page}.")
+            logger.error(
+                "An unexpected error occurred during user status fetching: %s",
+                e,
+                exc_info=True,
+            )
+            raise ParsingError(
+                "An unexpected error occurred during user status fetching."
+            ) from e
+        logger.info(
+            "Found %s users on page %s.",
+            len(users_id),
+            page,
+        )
         return Pagination[int](
             results=users_id,
             limit=limit,
             page=page,
             total=len(users_id),
-            has_next_page=next_page_link is not None
+            has_next_page=next_page_link is not None,
         )
 
     def _extract_user_ids_from_html(self, soup) -> list[int]:
@@ -289,23 +350,34 @@ class BookService(BaseSkoobService):
 
         Examples
         --------
-        >>> html = "<div class='livro-leitor-container'><a href='/usuario/1-name'></a></div>"
-        >>> service._extract_user_ids_from_html(BeautifulSoup(html, 'html.parser'))
+        >>> html = (
+        ...     "<div class='livro-leitor-container'>"
+        ...     "<a href='/usuario/1-name'></a></div>"
+        ... )
+        >>> service._extract_user_ids_from_html(
+        ...     BeautifulSoup(html, 'html.parser')
+        ... )
         [1]
         """
-        users_html = safe_find_all(soup, 'div', {'class': 'livro-leitor-container'})
+        users_html = safe_find_all(
+            soup, "div", {"class": "livro-leitor-container"}
+        )
         users_id = []
         for user_div in users_html:
-            user_link = safe_find(user_div, 'a')
-            href = get_tag_attr(user_link, 'href')
+            user_link = safe_find(user_div, "a")
+            href = get_tag_attr(user_link, "href")
             if href:
                 user_id = get_user_id_from_url(href)
                 if user_id:
                     users_id.append(int(user_id))
                 else:
-                    logger.warning(f"Could not extract user ID from URL: {href}")
+                    logger.warning(
+                        f"Could not extract user ID from URL: {href}"
+                    )
             else:
-                logger.warning("Skipping user_div due to missing 'a' tag or href attribute.")
+                logger.warning(
+                    "Skipping user_div due to missing 'a' tag or href attribute."
+                )
         return users_id
 
     def _extract_edition_id_from_reviews_page(self, soup) -> int | None:
@@ -324,19 +396,28 @@ class BookService(BaseSkoobService):
 
         Examples
         --------
-        >>> html = "<div id='pg-livro-menu-principal-container'><a href='/livro/1-ed3'></a></div>"
-        >>> service._extract_edition_id_from_reviews_page(BeautifulSoup(html, 'html.parser'))
+        >>> html = (
+        ...     "<div id='pg-livro-menu-principal-container'>"
+        ...     "<a href='/livro/1-ed3'></a></div>"
+        ... )
+        >>> service._extract_edition_id_from_reviews_page(
+        ...     BeautifulSoup(html, 'html.parser')
+        ... )
         3
         """
-        menu_div = safe_find(soup, 'div', {'id': 'pg-livro-menu-principal-container'})
-        menu_div_a = safe_find(menu_div, 'a') if menu_div else None
-        href = get_tag_attr(menu_div_a, 'href')
+        menu_div = safe_find(
+            soup, "div", {"id": "pg-livro-menu-principal-container"}
+        )
+        menu_div_a = safe_find(menu_div, "a") if menu_div else None
+        href = get_tag_attr(menu_div_a, "href")
         if href:
             extracted_edition_id = get_book_edition_id_from_url(href)
             if extracted_edition_id:
                 return int(extracted_edition_id)
             else:
-                logger.warning(f"Could not extract edition_id from URL: {href}")
+                logger.warning(
+                    f"Could not extract edition_id from URL: {href}"
+                )
         return None
 
     def _parse_review(
@@ -365,24 +446,42 @@ class BookService(BaseSkoobService):
         Examples
         --------
         >>> html = "<div id='resenha1'></div>"
-        >>> service._parse_review(BeautifulSoup(html, 'html.parser'), 1, None)
+        >>> service._parse_review(
+        ...     BeautifulSoup(html, 'html.parser'),
+        ...     1,
+        ...     None,
+        ... )
         ... # doctest: +ELLIPSIS
         """
-        review_id_str = get_tag_attr(r, 'id')
-        review_id = int(review_id_str.replace('resenha', '')) if review_id_str else None
+        review_id_str = get_tag_attr(r, "id")
+        review_id = (
+            int(review_id_str.replace("resenha", ""))
+            if review_id_str
+            else None
+        )
         if review_id is None:
-            logger.warning(f"Skipping review due to missing or invalid ID: {get_tag_attr(r, 'id')}")
+            logger.warning(
+                f"Skipping review due to missing or invalid ID: {get_tag_attr(r, 'id')}"
+            )
             return None
-        user_link = safe_find(r, 'a', {'href': re.compile(r'/usuario/')})
-        user_url = get_tag_attr(user_link, 'href')
+        user_link = safe_find(r, "a", {"href": re.compile(r"/usuario/")})
+        user_url = get_tag_attr(user_link, "href")
         user_id = int(get_user_id_from_url(user_url)) if user_url else None
         if user_id is None:
-            logger.warning(f"Skipping review {review_id} due to missing user ID.")
+            logger.warning(
+                f"Skipping review {review_id} due to missing user ID."
+            )
             return None
-        star_tag = safe_find(r, 'star-rating')
-        rating = float(get_tag_attr(star_tag, 'rate')) if star_tag and get_tag_attr(star_tag, 'rate') else 0.0
-        comment_div = safe_find(r, 'div', {'id': re.compile(r'resenhac\d+')})
-        date, review_text = self._extract_review_date_and_text(comment_div, review_id)
+        star_tag = safe_find(r, "star-rating")
+        rating = (
+            float(get_tag_attr(star_tag, "rate"))
+            if star_tag and get_tag_attr(star_tag, "rate")
+            else 0.0
+        )
+        comment_div = safe_find(r, "div", {"id": re.compile(r"resenhac\d+")})
+        date, review_text = self._extract_review_date_and_text(
+            comment_div, review_id
+        )
         return BookReview(
             review_id=review_id,
             book_id=book_id,
@@ -390,10 +489,12 @@ class BookService(BaseSkoobService):
             user_id=user_id,
             rating=rating,
             review_text=review_text,
-            reviewed_at=date
+            reviewed_at=date,
         )
 
-    def _extract_review_date_and_text(self, comment_div: Tag | None, review_id: int) -> tuple[datetime | None, str]:
+    def _extract_review_date_and_text(
+        self, comment_div: Tag | None, review_id: int
+    ) -> tuple[datetime | None, str]:
         """
         Extracts the review date and text from the comment div.
 
@@ -411,32 +512,41 @@ class BookService(BaseSkoobService):
 
         Examples
         --------
-        >>> soup = BeautifulSoup('<span>01/01/2020</span> Great', 'html.parser')
+        >>> soup = BeautifulSoup(
+        ...     '<span>01/01/2020</span> Great',
+        ...     'html.parser',
+        ... )
         >>> service._extract_review_date_and_text(soup, 1)[1]
         'Great'
         """
         date = None
         review_text = ""
         if comment_div:
-            date_span = safe_find(comment_div, 'span')
+            date_span = safe_find(comment_div, "span")
             date_text = get_tag_text(date_span, strip=True)
             if date_text:
                 try:
-                    date = datetime.strptime(date_text, '%d/%m/%Y')
+                    date = datetime.strptime(date_text, "%d/%m/%Y")
                 except ValueError:
-                    logger.warning(f"Could not parse date '{date_text}' for review {review_id}. Setting to None.")
+                    logger.warning(
+                        f"Could not parse date '{date_text}' for review {review_id}. Setting to None."
+                    )
             content_parts = []
             if date_span:
                 for sibling in date_span.next_siblings:
                     if isinstance(sibling, Tag):
-                        content_parts.append(sibling.get_text(separator='\n', strip=True))
+                        content_parts.append(
+                            sibling.get_text(separator="\n", strip=True)
+                        )
                     elif isinstance(sibling, str):
                         stripped_text = sibling.strip()
                         if stripped_text:
                             content_parts.append(stripped_text)
             else:
-                content_parts.append(comment_div.get_text(separator='\n', strip=True))
-            review_text = '\n'.join(filter(None, content_parts)).strip()
+                content_parts.append(
+                    comment_div.get_text(separator="\n", strip=True)
+                )
+            review_text = "\n".join(filter(None, content_parts)).strip()
         return date, review_text
 
     def _parse_search_result(self, book_div: Tag) -> BookSearchResult | None:
@@ -459,19 +569,23 @@ class BookService(BaseSkoobService):
         >>> service._parse_search_result(BeautifulSoup(html, 'html.parser'))
         BookSearchResult(...)
         """
-        container = safe_find(book_div, 'a', {'class': 'capa-link-item'})
+        container = safe_find(book_div, "a", {"class": "capa-link-item"})
         if not container:
-            logger.warning("Skipping book_div due to missing 'capa-link-item' container.")
+            logger.warning(
+                "Skipping book_div due to missing 'capa-link-item' container."
+            )
             return None
 
-        title = get_tag_attr(container, 'title')
+        title = get_tag_attr(container, "title")
         book_url = f'{self.base_url}{get_tag_attr(container, "href")}'
         img_url = self._extract_img_url(container)
         try:
             book_id = int(get_book_id_from_url(book_url))
             edition_id = int(get_book_edition_id_from_url(book_url))
         except Exception:
-            logger.warning(f"Skipping book_div due to invalid book/edition id in url: {book_url}")
+            logger.warning(
+                f"Skipping book_div due to invalid book/edition id in url: {book_url}"
+            )
             return None
 
         publisher, isbn = self._extract_publisher_and_isbn(book_div)
@@ -484,7 +598,7 @@ class BookService(BaseSkoobService):
             isbn=isbn,
             url=book_url,
             cover_url=img_url,
-            rating=rating
+            rating=rating,
         )
 
     def _extract_img_url(self, container: Tag) -> str:
@@ -508,12 +622,14 @@ class BookService(BaseSkoobService):
         'https://img.com/c.jpg'
         """
         if container.img and isinstance(container.img, Tag):
-            src = get_tag_attr(container.img, 'src')
-            if src and 'https' in src:
+            src = get_tag_attr(container.img, "src")
+            if src and "https" in src:
                 return f'https{src.split("https")[-1].strip()}'
-        return ''
+        return ""
 
-    def _extract_publisher_and_isbn(self, book_div: Tag) -> tuple[str | None, str | None]:
+    def _extract_publisher_and_isbn(
+        self, book_div: Tag
+    ) -> tuple[str | None, str | None]:
         """
         Extracts publisher and ISBN information from a book search result div.
 
@@ -533,11 +649,14 @@ class BookService(BaseSkoobService):
         >>> service._extract_publisher_and_isbn(BeautifulSoup(html, 'html.parser'))
         ('Editora', None)
         """
-        detalhes2sub = safe_find(book_div, 'div', {'class': 'detalhes-2-sub'})
+        detalhes2sub = safe_find(book_div, "div", {"class": "detalhes-2-sub"})
         detalhes2sub_div = detalhes2sub.div if detalhes2sub else None
-        spans = safe_find_all(detalhes2sub_div, 'span') if detalhes2sub_div else []
+        spans = (
+            safe_find_all(detalhes2sub_div, "span") if detalhes2sub_div else []
+        )
         cleaned_spans = [
-            text for span in spans
+            text
+            for span in spans
             if (text := span.get_text(strip=True)) and text != "|"
         ]
         isbn_pattern = re.compile(r"^\d{9,13}$|^B0[A-Z0-9]{8,}$")
@@ -572,15 +691,17 @@ class BookService(BaseSkoobService):
         >>> service._extract_rating(BeautifulSoup(html, 'html.parser'), 'Example')
         4.5
         """
-        star_mini = safe_find(book_div, 'div', {'class': 'star-mini'})
+        star_mini = safe_find(book_div, "div", {"class": "star-mini"})
         if star_mini:
-            strong_tag = safe_find(star_mini, 'strong')
+            strong_tag = safe_find(star_mini, "strong")
             rating_text = get_tag_text(strong_tag)
             if rating_text:
                 try:
-                    return float(rating_text.replace(',', '.'))
+                    return float(rating_text.replace(",", "."))
                 except ValueError:
-                    logger.warning(f"Could not parse rating '{rating_text}' for book '{title}'. Setting to None.")
+                    logger.warning(
+                        f"Could not parse rating '{rating_text}' for book '{title}'. Setting to None."
+                    )
         return None
 
     def _extract_total_results(self, soup) -> int:
@@ -602,10 +723,10 @@ class BookService(BaseSkoobService):
         >>> service._extract_total_results(BeautifulSoup("<div class='contador'>1 encontrados</div>", 'html.parser'))
         1
         """
-        total_results_tag = safe_find(soup, 'div', {'class': 'contador'})
+        total_results_tag = safe_find(soup, "div", {"class": "contador"})
         if total_results_tag:
             total_results_text = get_tag_text(total_results_tag)
-            match = re.search(r'(\d+)\s+encontrados', total_results_text)
+            match = re.search(r"(\d+)\s+encontrados", total_results_text)
             if match:
                 return int(match.group(1))
         return 0
@@ -631,12 +752,32 @@ class BookService(BaseSkoobService):
         ''
         """
         json_data["url"] = f"{self.base_url}{json_data['url']}"
-        json_data["isbn"] = None if str(json_data.get("isbn", "0")) == "0" else json_data["isbn"]
-        json_data["autor"] = None if json_data.get("autor", "").lower() == "não especificado" else json_data["autor"]
+        json_data["isbn"] = (
+            None
+            if str(json_data.get("isbn", "0")) == "0"
+            else json_data["isbn"]
+        )
+        json_data["autor"] = (
+            None
+            if json_data.get("autor", "").lower() == "não especificado"
+            else json_data["autor"]
+        )
         json_data["serie"] = json_data.get("serie") or None
-        json_data["volume"] = None if not json_data.get("volume") or str(json_data["volume"]) == "0" else str(json_data["volume"])
-        json_data["mes"] = None if not json_data.get("mes") or str(json_data["mes"]).strip() == "" else json_data["mes"]
+        json_data["volume"] = (
+            None
+            if not json_data.get("volume") or str(json_data["volume"]) == "0"
+            else str(json_data["volume"])
+        )
+        json_data["mes"] = (
+            None
+            if not json_data.get("mes") or str(json_data["mes"]).strip() == ""
+            else json_data["mes"]
+        )
         img_url = json_data.get("img_url", "")
-        json_data["cover_url"] = f'https{img_url.split("https")[-1].strip()}' if img_url and "https" in img_url else ""
+        json_data["cover_url"] = (
+            f'https{img_url.split("https")[-1].strip()}'
+            if img_url and "https" in img_url
+            else ""
+        )
         generos = json_data.get("generos")
         json_data["generos"] = generos if generos else None

--- a/pyskoob/client.py
+++ b/pyskoob/client.py
@@ -13,6 +13,7 @@ class SkoobClient:
     >>> with SkoobClient() as client:
     ...     client.auth.login_with_cookies("token")
     """
+
     def __init__(self):
         """
         Initializes the SkoobClient.

--- a/pyskoob/exceptions.py
+++ b/pyskoob/exceptions.py
@@ -1,3 +1,4 @@
 class ParsingError(Exception):
     """Custom exception for errors during HTML parsing."""
+
     pass

--- a/pyskoob/http/client.py
+++ b/pyskoob/http/client.py
@@ -39,7 +39,9 @@ class SyncHTTPClient(Protocol):
     def get(self, url: str, **kwargs: Any) -> HTTPResponse:
         """Send a GET request."""
 
-    def post(self, url: str, data: Any | None = None, **kwargs: Any) -> HTTPResponse:
+    def post(
+        self, url: str, data: Any | None = None, **kwargs: Any
+    ) -> HTTPResponse:
         """Send a POST request."""
 
     def close(self) -> None:
@@ -61,7 +63,9 @@ class AsyncHTTPClient(Protocol):
     async def get(self, url: str, **kwargs: Any) -> HTTPResponse:
         """Send an asynchronous GET request."""
 
-    async def post(self, url: str, data: Any | None = None, **kwargs: Any) -> HTTPResponse:
+    async def post(
+        self, url: str, data: Any | None = None, **kwargs: Any
+    ) -> HTTPResponse:
         """Send an asynchronous POST request."""
 
     async def close(self) -> None:

--- a/pyskoob/http/httpx.py
+++ b/pyskoob/http/httpx.py
@@ -28,7 +28,9 @@ class HttpxSyncClient(SyncHTTPClient):
     def get(self, url: str, **kwargs: Any) -> HTTPResponse:
         return self._client.get(url, **kwargs)
 
-    def post(self, url: str, data: Any | None = None, **kwargs: Any) -> HTTPResponse:
+    def post(
+        self, url: str, data: Any | None = None, **kwargs: Any
+    ) -> HTTPResponse:
         return self._client.post(url, data=data, **kwargs)
 
     def close(self) -> None:
@@ -54,7 +56,9 @@ class HttpxAsyncClient(AsyncHTTPClient):
     async def get(self, url: str, **kwargs: Any) -> HTTPResponse:
         return await self._client.get(url, **kwargs)
 
-    async def post(self, url: str, data: Any | None = None, **kwargs: Any) -> HTTPResponse:
+    async def post(
+        self, url: str, data: Any | None = None, **kwargs: Any
+    ) -> HTTPResponse:
         return await self._client.post(url, data=data, **kwargs)
 
     async def close(self) -> None:

--- a/pyskoob/internal/base.py
+++ b/pyskoob/internal/base.py
@@ -15,6 +15,7 @@ class BaseHttpService:
     _client : SyncHTTPClient
         The HTTP client for making requests.
     """
+
     _base_url: str
 
     def __init__(self, client: SyncHTTPClient, base_url: str):
@@ -92,4 +93,6 @@ class BaseSkoobService(BaseHttpService):
         >>> BaseSkoobService(httpx.Client())
         <BaseSkoobService ...>
         """
-        super().__init__(client or HttpxSyncClient(), 'https://www.skoob.com.br')
+        super().__init__(
+            client or HttpxSyncClient(), "https://www.skoob.com.br"
+        )

--- a/pyskoob/models/__init__.py
+++ b/pyskoob/models/__init__.py
@@ -1,5 +1,12 @@
 from .book import Book, BookReview
-from .enums import BookcaseOption, BookLabel, BookSearch, BookStatus, BookUserStatus, UsersRelation
+from .enums import (
+    BookcaseOption,
+    BookLabel,
+    BookSearch,
+    BookStatus,
+    BookUserStatus,
+    UsersRelation,
+)
 from .pagination import Pagination
 from .user import User, UserBook, UserReadStats
 

--- a/pyskoob/models/book.py
+++ b/pyskoob/models/book.py
@@ -5,6 +5,7 @@ from pydantic import BaseModel, ConfigDict, Field
 
 class BookStats(BaseModel):
     """Aggregated statistics about a book derived from Skoob's API."""
+
     readers: int = Field(..., alias="qt_lido")
     currently_reading: int = Field(..., alias="qt_lendo")
     want_to_read: int = Field(..., alias="qt_vouler")
@@ -29,6 +30,7 @@ class BookStats(BaseModel):
 
 class Book(BaseModel):
     """Detailed information about a book edition."""
+
     book_id: int = Field(..., alias="livro_id")
     edition_id: int = Field(..., alias="id")
     title: str = Field(..., alias="titulo")
@@ -58,6 +60,7 @@ class Book(BaseModel):
 
 class BookSearchResult(BaseModel):
     """Lightweight representation returned by the search endpoint."""
+
     edition_id: int
     book_id: int
     title: str
@@ -72,12 +75,14 @@ class BookSearchResult(BaseModel):
 
 class BookTag(BaseModel):
     """Tags associated with a book edition."""
+
     edition_id: int
     tags: list[str] | None = None
 
 
 class BookReview(BaseModel):
     """User review for a specific book edition."""
+
     review_id: int
     book_id: int
     edition_id: int | None

--- a/pyskoob/models/enums.py
+++ b/pyskoob/models/enums.py
@@ -5,13 +5,15 @@ from enum import IntEnum, StrEnum
 
 class BookShelf(StrEnum):
     """Shelf categories available on the website."""
-    COMIC = 'comic'
-    BOOK = 'book'
-    MAGAZINE = 'magazine'
+
+    COMIC = "comic"
+    BOOK = "book"
+    MAGAZINE = "magazine"
 
 
 class BookLabel(IntEnum):
     """Numeric labels used by the API when tagging books."""
+
     FAVORITE = 8
     WISHLIST = 9
     OWNED = 6
@@ -21,16 +23,18 @@ class BookLabel(IntEnum):
 
 class BookSearch(StrEnum):
     """Search modes accepted by the book search endpoint."""
-    ALL = 'geral'
-    ISBN = 'isbn'
-    AUTHOR = 'autor'
-    PUBLISHER = 'editora'
-    TITLE = 'titulo'
-    TAGS = 'tags'
+
+    ALL = "geral"
+    ISBN = "isbn"
+    AUTHOR = "autor"
+    PUBLISHER = "editora"
+    TITLE = "titulo"
+    TAGS = "tags"
 
 
 class BookStatus(IntEnum):
     """Status codes for a user's relationship with a book."""
+
     READ = 1
     CURRENTLY_READING = 2
     WANT_TO_READ = 3
@@ -40,19 +44,21 @@ class BookStatus(IntEnum):
 
 class BookUserStatus(StrEnum):
     """URL slugs representing shelves in user listings."""
-    READ = 'leram'
-    CURRENTLY_READING = 'lendo'
-    WANT_TO_READ = 'vaoler'
-    REREADING = 'relendo'
-    ABANDONED = 'abandonaram'
-    FAVORITED = 'favoritos'
-    TRADABLE = 'trocam'
-    WISHLISTED = 'desejam'
-    RATED = 'avaliaram'
+
+    READ = "leram"
+    CURRENTLY_READING = "lendo"
+    WANT_TO_READ = "vaoler"
+    REREADING = "relendo"
+    ABANDONED = "abandonaram"
+    FAVORITED = "favoritos"
+    TRADABLE = "trocam"
+    WISHLISTED = "desejam"
+    RATED = "avaliaram"
 
 
 class BookcaseOption(IntEnum):
     """Filter options for a user's virtual bookcase."""
+
     ALL = 0
     READ = 1
     CURRENTLY_READING = 2
@@ -73,19 +79,22 @@ class BookcaseOption(IntEnum):
 
 class UsersRelation(StrEnum):
     """Types of relationship between users."""
-    FRIENDS = 'amigos'
-    FOLLOWING = 'seguidos'
-    FOLLOWERS = 'seguidores'
+
+    FRIENDS = "amigos"
+    FOLLOWING = "seguidos"
+    FOLLOWERS = "seguidores"
 
 
 class UserGender(StrEnum):
     """Gender codes returned by the API."""
-    MALE = 'M'
-    FEMALE = 'F'
+
+    MALE = "M"
+    FEMALE = "F"
 
 
 class BrazilianState(StrEnum):
     """Brazilian state abbreviations used in user profiles."""
+
     ACRE = "AC"
     ALAGOAS = "AL"
     AMAPA = "AP"

--- a/pyskoob/models/pagination.py
+++ b/pyskoob/models/pagination.py
@@ -2,7 +2,7 @@ from typing import Generic, TypeVar
 
 from pydantic import BaseModel
 
-T = TypeVar('T')
+T = TypeVar("T")
 
 
 class Pagination(BaseModel, Generic[T]):

--- a/pyskoob/models/user.py
+++ b/pyskoob/models/user.py
@@ -5,6 +5,7 @@ from pydantic import BaseModel, ConfigDict, Field, HttpUrl
 
 class UserSearch(BaseModel):
     """Minimal user information returned by search queries."""
+
     id: int
     username: str
     name: str
@@ -15,6 +16,7 @@ class UserSearch(BaseModel):
 
 class User(BaseModel):
     """Profile information for a Skoob user."""
+
     id: int
     name: str = Field(..., alias="nome")
     nickname: str = Field(..., alias="apelido")
@@ -43,6 +45,7 @@ class User(BaseModel):
 
 class UserBook(BaseModel):
     """Status of a specific book in a user's shelf."""
+
     user_id: int
     book_id: int
     edition_id: int
@@ -61,6 +64,7 @@ class UserBook(BaseModel):
 
 class UserReadStats(BaseModel):
     """Reading progress statistics for a particular year."""
+
     user_id: int
     year: int
 
@@ -77,6 +81,7 @@ class UserReadStats(BaseModel):
 
 class UserStats(BaseModel):
     """Aggregated counts describing the user's activity on Skoob."""
+
     books: int = Field(0, alias="livros")
     magazines: int = Field(0, alias="revistas")
     comics: int = Field(0, alias="quadrinhos")

--- a/pyskoob/profile.py
+++ b/pyskoob/profile.py
@@ -64,10 +64,10 @@ class SkoobProfileService(BaseSkoobService):
         True
         """
         self._validate_login()
-        url = f'{self.base_url}/v1/label_add/{edition_id}/{label.value}'
+        url = f"{self.base_url}/v1/label_add/{edition_id}/{label.value}"
         response = self.client.get(url)
         response.raise_for_status()
-        return response.json().get('success', False)
+        return response.json().get("success", False)
 
     def remove_book_label(self, edition_id: int) -> bool:
         """
@@ -89,10 +89,10 @@ class SkoobProfileService(BaseSkoobService):
         True
         """
         self._validate_login()
-        url = f'{self.base_url}/v1/label_del/{edition_id}'
+        url = f"{self.base_url}/v1/label_del/{edition_id}"
         response = self.client.get(url)
         response.raise_for_status()
-        return response.json().get('success', False)
+        return response.json().get("success", False)
 
     def update_book_status(self, edition_id: int, status: BookStatus) -> bool:
         """
@@ -116,10 +116,10 @@ class SkoobProfileService(BaseSkoobService):
         True
         """
         self._validate_login()
-        url = f'{self.base_url}/v1/shelf_add/{edition_id}/{status.value}'
+        url = f"{self.base_url}/v1/shelf_add/{edition_id}/{status.value}"
         response = self.client.get(url)
         response.raise_for_status()
-        return response.json().get('success', False)
+        return response.json().get("success", False)
 
     def remove_book_status(self, edition_id: int) -> bool:
         """
@@ -141,10 +141,10 @@ class SkoobProfileService(BaseSkoobService):
         True
         """
         self._validate_login()
-        url = f'{self.base_url}/v1/shelf_del/{edition_id}'
+        url = f"{self.base_url}/v1/shelf_del/{edition_id}"
         response = self.client.get(url)
         response.raise_for_status()
-        return response.json().get('success', False)
+        return response.json().get("success", False)
 
     def change_book_shelf(self, edition_id: int, bookshelf: BookShelf) -> bool:
         """
@@ -168,7 +168,7 @@ class SkoobProfileService(BaseSkoobService):
         True
         """
         self._validate_login()
-        url = f'{self.base_url}/estante/prateleira/{edition_id}/{bookshelf.value}'
+        url = f"{self.base_url}/estante/prateleira/{edition_id}/{bookshelf.value}"
         response = self.client.get(url)
         response.raise_for_status()
         return True
@@ -203,12 +203,12 @@ class SkoobProfileService(BaseSkoobService):
         """
         self._validate_login()
         if not (0 <= ranking <= 5):
-            raise ValueError('Rating must be between 0 and 5.')
+            raise ValueError("Rating must be between 0 and 5.")
 
-        url = f'{self.base_url}/v1/book_rate/{edition_id}/{ranking}'
+        url = f"{self.base_url}/v1/book_rate/{edition_id}/{ranking}"
         response = self.client.get(url)
         response.raise_for_status()
 
-        if not response.json().get('success'):
-            raise RuntimeError('Failed to rate the book.')
+        if not response.json().get("success"):
+            raise RuntimeError("Failed to rate the book.")
         return True

--- a/pyskoob/utils/bs4_utils.py
+++ b/pyskoob/utils/bs4_utils.py
@@ -5,9 +5,7 @@ from bs4.element import PageElement
 
 
 def safe_find(
-    soup: BeautifulSoup | Tag | None,
-    name: str,
-    attrs: dict | None = None
+    soup: BeautifulSoup | Tag | None, name: str, attrs: dict | None = None
 ) -> Tag | None:
     """
     Safely finds a single Tag in a BeautifulSoup object.
@@ -40,9 +38,7 @@ def safe_find(
 
 
 def safe_find_all(
-    soup: BeautifulSoup | Tag | None,
-    name: str,
-    attrs: dict | None = None
+    soup: BeautifulSoup | Tag | None, name: str, attrs: dict | None = None
 ) -> list[Tag]:
     """
     Safely finds all Tags in a BeautifulSoup object.
@@ -72,10 +68,7 @@ def safe_find_all(
     return [tag for tag in all_found if isinstance(tag, Tag)]
 
 
-def get_tag_text(
-    tag: PageElement | None,
-    strip: bool = True
-) -> str:
+def get_tag_text(tag: PageElement | None, strip: bool = True) -> str:
     """
     Gets the text of a Tag, returning an empty string if the tag is None.
 
@@ -101,11 +94,7 @@ def get_tag_text(
     return ""
 
 
-def get_tag_attr(
-    tag: Tag | None,
-    attr: str,
-    default: Any = None
-) -> Any:
+def get_tag_attr(tag: Tag | None, attr: str, default: Any = None) -> Any:
     """
     Gets an attribute from a Tag, returning a default value if the tag is None.
 

--- a/pyskoob/utils/skoob_parser_utils.py
+++ b/pyskoob/utils/skoob_parser_utils.py
@@ -17,12 +17,12 @@ def get_book_id_from_url(url: str) -> str:
     >>> get_book_id_from_url('https://www.skoob.com.br/livro/1-ed1.html')
     '1'
     """
-    filename = url.split('/')[-1]
-    parts = filename.split('-')
+    filename = url.split("/")[-1]
+    parts = filename.split("-")
     if parts[0].isdigit():
         return parts[0]
     else:
-        return parts[-1].split('ed')[0].strip()
+        return parts[-1].split("ed")[0].strip()
 
 
 def get_book_edition_id_from_url(url: str) -> str:
@@ -44,7 +44,7 @@ def get_book_edition_id_from_url(url: str) -> str:
     >>> get_book_edition_id_from_url('https://www.skoob.com.br/livro/1-ed10.html')
     '10'
     """
-    return url.split('ed')[-1].replace('.html', '')
+    return url.split("ed")[-1].replace(".html", "")
 
 
 def get_user_id_from_url(url: str) -> str:
@@ -66,4 +66,4 @@ def get_user_id_from_url(url: str) -> str:
     >>> get_user_id_from_url('https://www.skoob.com.br/usuario/5-name')
     '5'
     """
-    return url.split('/')[-1].split('-')[0]
+    return url.split("/")[-1].split("-")[0]


### PR DESCRIPTION
## Summary
- run autopep8 across codebase to improve PEP 8 compliance
- shorten long strings in a few places to keep lines under 79 characters

## Testing
- `flake8 pyskoob` *(fails: E501 line too long)*

------
https://chatgpt.com/codex/tasks/task_e_688ca0876ca88329991b3f6be65d9f79