### PR TITLE
Increase coverage with additional tests

### DIFF
--- a/tests/test_author_models.py
+++ b/tests/test_author_models.py
@@ -1,0 +1,28 @@
+import pytest
+
+from pyskoob.models.author import (
+    AuthorBook,
+    AuthorProfile,
+    AuthorStats,
+    AuthorVideo,
+)
+
+
+def test_author_profile_defaults():
+    profile = AuthorProfile(name="A")
+    assert profile.links == {}
+    assert profile.tags == []
+    assert profile.gender_percentages == {}
+    assert profile.books == [] and profile.videos == []
+    assert isinstance(profile.stats, AuthorStats)
+
+
+@pytest.mark.parametrize(
+    "model,expected",
+    [
+        (AuthorBook(), {"url": None, "title": None, "img_url": None}),
+        (AuthorVideo(), {"url": None, "thumbnail_url": None, "title": None}),
+    ],
+)
+def test_author_models_defaults(model, expected):
+    assert model.model_dump() == expected

--- a/tests/test_book_helpers.py
+++ b/tests/test_book_helpers.py
@@ -1,0 +1,76 @@
+from datetime import datetime
+from typing import cast
+
+import pytest
+from bs4 import BeautifulSoup
+from conftest import DummyClient
+
+from pyskoob.books import BookService
+from pyskoob.http.client import SyncHTTPClient
+
+
+def make_service(html: str = ""):
+    client = DummyClient(text=html)
+    return BookService(cast(SyncHTTPClient, client)), client
+
+
+@pytest.mark.parametrize(
+    "html,expected",
+    [
+        (
+            "<div class='detalhes-2-sub'><div><span>1234567890123</span><span>Pub</span></div></div>",
+            ("Pub", "1234567890123"),
+        ),
+        (
+            "<div class='detalhes-2-sub'><div><span>1234567890123</span></div></div>",
+            (None, "1234567890123"),
+        ),
+        (
+            "<div class='detalhes-2-sub'><div><span>|</span><span>Pub</span></div></div>",
+            (None, None),
+        ),
+        ("<div></div>", (None, None)),
+    ],
+)
+def test_extract_publisher_and_isbn(html, expected):
+    service, _ = make_service()
+    soup = BeautifulSoup(html, "html.parser")
+    result = service._extract_publisher_and_isbn(soup)
+    assert result == expected
+
+
+def test_extract_user_ids_and_edition_id():
+    html_users = (
+        "<div class='livro-leitor-container'><a href='/usuario/1-a'></a></div>"
+        "<div class='livro-leitor-container'><a href='/usuario/2-b'></a></div>"
+        "<div class='livro-leitor-container'><span>No link</span></div>"
+    )
+    service, _ = make_service()
+    soup = BeautifulSoup(html_users, "html.parser")
+    ids = service._extract_user_ids_from_html(soup)
+    assert ids == [1, 2]
+
+    html_reviews = (
+        "<div id='pg-livro-menu-principal-container'>"
+        "<a href='/livro/10-ed5.html'></a></div>"
+    )
+    soup = BeautifulSoup(html_reviews, "html.parser")
+    edition = service._extract_edition_id_from_reviews_page(soup)
+    assert edition == 5
+    assert service._extract_edition_id_from_reviews_page(BeautifulSoup("<div></div>", "html.parser")) is None
+
+
+@pytest.mark.parametrize(
+    "html,date,text",
+    [
+        ("<div id='c'><span>01/01/2020</span>Great</div>", datetime(2020, 1, 1), "Great"),
+        ("<div id='c'><span>bad</span>Nice</div>", None, "Nice"),
+        ("<div id='c'>Only</div>", None, "Only"),
+    ],
+)
+def test_extract_review_date_and_text(html, date, text):
+    service, _ = make_service()
+    soup = BeautifulSoup(html, "html.parser")
+    result_date, result_text = service._extract_review_date_and_text(soup.div, 1)
+    assert result_date == date
+    assert result_text == text

--- a/tests/test_httpx_async_client.py
+++ b/tests/test_httpx_async_client.py
@@ -1,0 +1,25 @@
+import asyncio
+
+import httpx
+
+from pyskoob.http.httpx import HttpxAsyncClient
+
+
+def test_async_client_get_post_aclose():
+    async def handler(request: httpx.Request) -> httpx.Response:
+        if request.method == "GET":
+            return httpx.Response(200, text="g")
+        if request.method == "POST":
+            return httpx.Response(200, text=request.content.decode())
+        return httpx.Response(404)
+
+    async def main():
+        transport = httpx.MockTransport(handler)
+        client = HttpxAsyncClient(transport=transport)
+        resp = await client.get("https://x")
+        assert resp.text == "g"
+        resp2 = await client.post("https://x", data="p")
+        assert resp2.text == "p"
+        await client.close()
+
+    asyncio.run(main())


### PR DESCRIPTION
## Summary
- add tests for author-related models
- cover helper methods in `BookService`
- add async client integration test
- exercise untested branches of `UserService`

## Testing
- `ruff check tests/test_author_models.py tests/test_book_helpers.py tests/test_httpx_async_client.py tests/test_skoob_user_service.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688cb25fa4c88329ad05441d7cc085c8

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added new unit tests for author-related models, verifying default attribute values and serialization.
  * Introduced tests for book helper methods, ensuring correct HTML parsing for publisher, ISBN, user IDs, edition IDs, and review extraction.
  * Added asynchronous tests for HTTP client behavior with GET and POST requests.
  * Expanded user service test coverage to include user retrieval, not-found handling, and review parsing with invalid dates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->