### PR TITLE
fix(httpx): avoid post deprecation warning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) 
 - Initial structure for the changelog.
 - AuthorService for searching authors.
 - Example script demonstrating AuthorService usage.
+### Fixed
+- Avoided ``httpx`` deprecation warning when posting raw bytes or text.
 
 ## [0.1.0] - 2025-07-30
 ### Added

--- a/pyskoob/http/httpx.py
+++ b/pyskoob/http/httpx.py
@@ -32,6 +32,28 @@ class HttpxSyncClient(SyncHTTPClient):
     def post(
         self, url: str, data: Any | None = None, **kwargs: Any
     ) -> HTTPResponse:
+        """Send a POST request.
+
+        Parameters
+        ----------
+        url:
+            The request URL.
+        data:
+            Optional request payload. If ``data`` is ``bytes`` or ``str`` it is
+            forwarded as ``content`` to avoid deprecation warnings from
+            ``httpx``. Other types are passed through unchanged.
+        **kwargs:
+            Additional arguments forwarded to ``httpx.Client.post``.
+
+        Returns
+        -------
+        HTTPResponse
+            The HTTP response instance returned by ``httpx``.
+        """
+
+        if isinstance(data, (str | bytes)):
+            return self._client.post(url, content=data, **kwargs)
+
         return self._client.post(url, data=data, **kwargs)
 
     def close(self) -> None:
@@ -60,6 +82,28 @@ class HttpxAsyncClient(AsyncHTTPClient):
     async def post(
         self, url: str, data: Any | None = None, **kwargs: Any
     ) -> HTTPResponse:
+        """Send a POST request asynchronously.
+
+        Parameters
+        ----------
+        url:
+            The request URL.
+        data:
+            Optional request payload. If ``data`` is ``bytes`` or ``str`` it is
+            forwarded as ``content`` to avoid deprecation warnings from
+            ``httpx``. Other types are passed through unchanged.
+        **kwargs:
+            Additional arguments forwarded to ``httpx.AsyncClient.post``.
+
+        Returns
+        -------
+        HTTPResponse
+            The HTTP response instance returned by ``httpx``.
+        """
+
+        if isinstance(data, (str | bytes)):
+            return await self._client.post(url, content=data, **kwargs)
+
         return await self._client.post(url, data=data, **kwargs)
 
     async def close(self) -> None:


### PR DESCRIPTION
## Summary
- avoid deprecated `data` usage in httpx clients when posting raw bytes or text
- document the fix in the changelog

## Testing
- `ruff check .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688cd5f3612883298242605683279d6f

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved an issue to prevent deprecation warnings when posting raw bytes or text using the HTTP client.

* **Documentation**
  * Improved documentation for HTTP client methods, providing clearer descriptions of parameters and behavior.

* **Chores**
  * Updated the changelog to reflect the recent bug fix.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->