### PR TITLE
Add MkDocs documentation site

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,21 @@
+name: Docs
+
+on:
+  pull_request:
+    branches: [main]
+  push:
+    branches: [main]
+
+jobs:
+  build-docs:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+      - name: Install dependencies
+        run: |
+          pip install -e .[docs]
+      - name: Build documentation
+        run: mkdocs build --strict

--- a/README.md
+++ b/README.md
@@ -8,6 +8,14 @@
 ## Overview
 PySkoob is a Python library that simplifies interacting with the Skoob website. It acts as an HTTP client, providing services for authentication, book searches, and profile access. The goal of the project is to streamline integrations and automation while offering an easy‑to‑use interface.
 
+## Documentation
+The full documentation is generated using [MkDocs](https://www.mkdocs.org/) and lives in the `docs/` folder. To preview it locally run:
+
+```bash
+pip install -e .[docs]
+mkdocs serve
+```
+
 ## Installation
 Create a virtual environment using [uv](https://github.com/astral-sh/uv) and
 install from PyPI:

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,28 @@
+# PySkoob Documentation
+
+Welcome to the **PySkoob** documentation. This site provides usage examples and a reference of the available services.
+
+## Installation
+
+```bash
+pip install scraper-skoob
+```
+
+## Usage
+
+```python
+from pyskoob.client import SkoobClient
+
+with SkoobClient() as client:
+    books = client.books.search("python").results
+```
+
+## API Reference
+
+::: pyskoob.client
+::: pyskoob.auth
+::: pyskoob.books
+::: pyskoob.authors
+::: pyskoob.users
+::: pyskoob.profile
+::: pyskoob.publishers

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,0 +1,18 @@
+site_name: PySkoob
+repo_url: https://github.com/YOUR_GITHUB_USER/pyskoob
+docs_dir: docs
+theme:
+  name: material
+  palette:
+    primary: indigo
+    accent: indigo
+markdown_extensions:
+  - admonition
+  - codehilite
+plugins:
+  - search
+  - mkdocstrings:
+      handlers:
+        python:
+          options:
+            docstring_style: numpy

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -65,6 +65,11 @@ dev = [
     "fastapi>=0.116.1",
     "uvicorn>=0.35.0",
 ]
+docs = [
+    "mkdocs>=1.6.0",
+    "mkdocs-material>=9.5.17",
+    "mkdocstrings[python]>=0.24.0",
+]
 
 [build-system]
 requires = ["setuptools>=65", "wheel"]


### PR DESCRIPTION
## Summary
- add MkDocs configuration to generate docs from docstrings
- provide index page with API reference via mkdocstrings
- install docs dependencies via new `docs` extra
- include docs build workflow in CI
- mention docs and how to build them in README

## Testing
- `ruff check .`
- `pytest -q`
- `mkdocs build --strict`


------
https://chatgpt.com/codex/tasks/task_e_688cfa3dc1fc8329a04781de71ee7457

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added comprehensive project documentation, including installation and usage guides.
  * Introduced an API reference section covering main modules.
  * Enabled local documentation preview with clear instructions in the README.

* **Chores**
  * Added a workflow to automatically build documentation on pull requests and main branch updates.
  * Included optional dependencies for documentation generation and preview.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->