### PR TITLE
feature: improve author search parsing

### DIFF
--- a/docs/author_service.md
+++ b/docs/author_service.md
@@ -1,0 +1,15 @@
+# Author Service
+
+The `AuthorService` provides search capabilities for authors on Skoob. It scrapes
+Skoob's HTML pages and returns lightweight results with the following fields:
+
+- `id`: numeric identifier extracted from the author URL
+- `name`: the author's display name
+- `nickname`: nickname shown below the name
+- `url`: absolute URL to the author's page on Skoob
+- `img_url`: avatar image URL
+
+Skoob displays publication, reader and follower counts on the search results
+page, but these values are often outdated when compared with the author's
+profile page. To avoid exposing misleading data, `AuthorService` intentionally
+omits these numbers.

--- a/examples/search_authors.py
+++ b/examples/search_authors.py
@@ -27,7 +27,7 @@ def main() -> None:
     with SkoobClient() as client:
         results = client.authors.search(args.query, page=args.page)
         for author in results.results:
-            print(f"{author.name} - {author.books} books")
+            print(f"{author.name} ({author.nickname}) - id {author.id}")
 
 
 if __name__ == "__main__":

--- a/pyskoob/models/author.py
+++ b/pyskoob/models/author.py
@@ -2,12 +2,10 @@ from pydantic import BaseModel, ConfigDict, Field
 
 
 class AuthorSearchResult(BaseModel):
+    id: int
     name: str
     url: str
     nickname: str
-    followers: int
-    readers: int
-    books: int
     img_url: str
 
     model_config = ConfigDict(from_attributes=True)

--- a/pyskoob/utils/skoob_parser_utils.py
+++ b/pyskoob/utils/skoob_parser_utils.py
@@ -67,3 +67,24 @@ def get_user_id_from_url(url: str) -> str:
     '5'
     """
     return url.split("/")[-1].split("-")[0]
+
+
+def get_author_id_from_url(url: str) -> str:
+    """Extract the author ID from a Skoob author URL.
+
+    Parameters
+    ----------
+    url : str
+        The Skoob author URL.
+
+    Returns
+    -------
+    str
+        The author ID.
+
+    Examples
+    --------
+    >>> get_author_id_from_url('https://www.skoob.com.br/autor/50-name')
+    '50'
+    """
+    return url.split("/")[-1].split("-")[0]

--- a/tests/test_skoob_author_service.py
+++ b/tests/test_skoob_author_service.py
@@ -14,21 +14,17 @@ def make_service(html: str = ""):
 def test_parse_search_result():
     html = (
         "<div style='border-bottom:#ccc 1px dotted; margin-bottom:10px;'>"
-        "<div><img class='img-rounded' src='img.jpg'/></div>"
-        "<a href='/autor/1-john'>John</a><i>nick</i>"
-        "<div class='autor-item-detalhe-2'>"
-        "<span> <i class='icon-book'></i> 3 publicacoes</span>"
-        "<span> | </span><span>2 leitores</span>"
-        "<span> | </span><span>5 seguidores</span>"
-        "</div></div><div class='contador'>1 encontrados</div>"
+        "<div><a href='/autor/1-john'><img class='img-rounded' src='img.jpg'/></a></div>"
+        "<strong><a href='/autor/1-john'>John</a></strong><i>nick</i>"
+        "<div class='autor-item-detalhe-2'></div></div>"
+        "<div class='contador'>1 encontrados</div>"
     )
     service, _ = make_service(html)
     result = service.search("john")
     assert result.total == 1
     author = result.results[0]
+    assert author.id == 1
     assert author.name == "John"
     assert author.nickname == "nick"
-    assert author.books == 3
-    assert author.readers == 2
-    assert author.followers == 5
+    assert author.url.endswith("/autor/1-john")
     assert author.img_url == "img.jpg"

--- a/tests/test_skoob_parser_utils.py
+++ b/tests/test_skoob_parser_utils.py
@@ -11,3 +11,7 @@ def test_get_book_edition_and_user_id():
     url = 'https://www.skoob.com.br/title-123ed456.html'
     assert spu.get_book_edition_id_from_url(url) == '456'
     assert spu.get_user_id_from_url('https://www.skoob.com.br/usuario/55-name') == '55'
+
+
+def test_get_author_id_from_url():
+    assert spu.get_author_id_from_url('https://www.skoob.com.br/autor/77-john') == '77'


### PR DESCRIPTION
## Summary
- return author ID in search results and fix name extraction
- drop publication, reader and follower counts from `AuthorSearchResult`
- provide `get_author_id_from_url` helper
- document the author service
- update tests and example accordingly

## Testing
- `ruff check .`
- `python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688cf9c9f8a083298a6267b2535046b5

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added documentation for the author search service, detailing returned fields and data accuracy considerations.
  * Introduced a utility to extract author IDs from Skoob URLs.

* **Improvements**
  * Search results now display author ID and nickname instead of book, reader, and follower counts.
  * Enhanced test coverage for author ID extraction and updated tests to reflect new author search result format.

* **Bug Fixes**
  * Removed outdated numeric stats from author search results to improve data accuracy.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->