### PR TITLE
Refactor docs workflow for least privilege

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -7,15 +7,11 @@ on:
     branches: [main]
 
 jobs:
-  build-and-deploy:
+  build-docs:
     runs-on: ubuntu-latest
-    permissions:
-      contents: write
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Set up Python
         uses: actions/setup-python@v5
@@ -28,6 +24,24 @@ jobs:
 
       - name: Build documentation
         run: mkdocs build --strict
+
+  deploy-docs:
+    needs: build-docs
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Install dependencies
+        run: |
+          pip install -e .[docs]
 
       - name: Deploy to GitHub Pages
         run: mkdocs gh-deploy --force --remote-branch gh-pages


### PR DESCRIPTION
## Summary
- split documentation build and deployment steps
- keep `contents: write` only for the deploy job
- drop redundant checkout token configuration

## Testing
- `ruff check .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688d0b8567a88329b184c572e4bd73b6

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved the documentation deployment workflow for better reliability and security by splitting it into separate build and deploy steps.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->