### PR TITLE
Expose public API

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ You can authenticate in two different ways:
 1. **Email and password**
 
     ```python
-    from pyskoob.client import SkoobClient
+    from pyskoob import SkoobClient
 
     with SkoobClient() as client:
         me = client.auth.login(email="you@example.com", password="secret")
@@ -47,7 +47,7 @@ You can authenticate in two different ways:
 2. **Session cookie**
 
     ```python
-    from pyskoob.client import SkoobClient
+    from pyskoob import SkoobClient
 
     with SkoobClient() as client:
         me = client.auth.login_with_cookies("PHPSESSID_TOKEN")
@@ -57,7 +57,7 @@ Once authenticated you can access all other services.
 
 ## Usage example
 ```python
-from pyskoob.client import SkoobClient
+from pyskoob import SkoobClient
 from pyskoob.models.enums import BookSearch
 
 with SkoobClient() as client:

--- a/docs/index.md
+++ b/docs/index.md
@@ -11,7 +11,7 @@ pip install scraper-skoob
 ## Usage
 
 ```python
-from pyskoob.client import SkoobClient
+from pyskoob import SkoobClient
 
 with SkoobClient() as client:
     books = client.books.search("python").results

--- a/examples/auth_user_profile.py
+++ b/examples/auth_user_profile.py
@@ -6,7 +6,7 @@ display basic information about the logged in user as a demonstration of
 the authentication and user APIs.
 """
 
-from pyskoob.client import SkoobClient
+from pyskoob import SkoobClient
 
 
 def main() -> None:

--- a/examples/pagination_search.py
+++ b/examples/pagination_search.py
@@ -5,7 +5,7 @@ pages until ``has_next_page`` is False. The title of each book is printed
 along with the page number from which it came.
 """
 
-from pyskoob.client import SkoobClient
+from pyskoob import SkoobClient
 from pyskoob.models.enums import BookSearch
 
 

--- a/examples/publisher_service_example.py
+++ b/examples/publisher_service_example.py
@@ -1,6 +1,6 @@
 """Example usage of the PublisherService."""
 
-from pyskoob.client import SkoobClient
+from pyskoob import SkoobClient
 
 
 def main() -> None:

--- a/examples/search_authors.py
+++ b/examples/search_authors.py
@@ -9,7 +9,7 @@ from __future__ import annotations
 
 import argparse
 
-from pyskoob.client import SkoobClient
+from pyskoob import SkoobClient
 
 
 def parse_args() -> argparse.Namespace:

--- a/examples/search_books.py
+++ b/examples/search_books.py
@@ -6,7 +6,7 @@ the search term or switch ``search_by`` to ``BookSearch.AUTHOR`` to search
 by an author's name instead.
 """
 
-from pyskoob.client import SkoobClient
+from pyskoob import SkoobClient
 from pyskoob.models.enums import BookSearch
 
 

--- a/pyskoob/__init__.py
+++ b/pyskoob/__init__.py
@@ -1,1 +1,11 @@
 """Public API for the PySkoob package."""
+
+from . import models
+from .client import SkoobClient
+from .exceptions import ParsingError
+
+__all__ = [
+    "SkoobClient",
+    "models",
+    "ParsingError",
+]

--- a/tests/integration/test_flow.py
+++ b/tests/integration/test_flow.py
@@ -1,7 +1,7 @@
 import httpx
 from conftest import make_user
 
-from pyskoob.client import SkoobClient
+from pyskoob import SkoobClient
 from pyskoob.http.httpx import HttpxSyncClient
 
 

--- a/tests/test_public_api.py
+++ b/tests/test_public_api.py
@@ -1,0 +1,8 @@
+import pyskoob
+
+
+def test_root_imports():
+    assert hasattr(pyskoob, "SkoobClient")
+    assert hasattr(pyskoob, "models")
+    assert hasattr(pyskoob, "ParsingError")
+

--- a/tests/test_skoob_client.py
+++ b/tests/test_skoob_client.py
@@ -1,5 +1,5 @@
 
-from pyskoob.client import SkoobClient
+from pyskoob import SkoobClient
 
 
 def test_client_context_manager(monkeypatch):


### PR DESCRIPTION
## Summary
- expose primary symbols in `pyskoob/__init__.py`
- update documentation and examples to import from root package
- adjust tests for new import path and add check for public API

## Testing
- `pip install -e .`
- `ruff check pyskoob examples docs tests`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688d1f6e5838832993d16dfafc86f6e3