### PR TITLE
docs: add advanced usage and API stability

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) 
 - Initial structure for the changelog.
 - AuthorService for searching authors.
 - Example script demonstrating AuthorService usage.
+- Documentation for pagination and asynchronous usage examples.
+- List of stable public API exports.
 ### Fixed
 - Avoided ``httpx`` deprecation warning when posting raw bytes or text.
 

--- a/docs/advanced_usage.md
+++ b/docs/advanced_usage.md
@@ -1,0 +1,42 @@
+# Advanced Usage
+
+This section shows more involved examples of working with PySkoob.
+
+## Handling Pagination
+
+Several services return a `Pagination` object that exposes the
+`has_next_page` flag. You can use this flag to iterate over all pages:
+
+```python
+from pyskoob import SkoobClient
+from pyskoob.models.enums import BookSearch
+
+with SkoobClient() as client:
+    page = 1
+    while True:
+        results = client.books.search("Python", BookSearch.TITLE, page=page)
+        for book in results.results:
+            print(f"[{page}] {book.title}")
+        if not results.has_next_page:
+            break
+        page += 1
+```
+
+## Asynchronous HTTP Client
+
+PySkoob ships with `HttpxAsyncClient` for making asynchronous HTTP requests.
+While the high level services are synchronous, you can use the async client
+when integrating with an async application:
+
+```python
+import asyncio
+from pyskoob import HttpxAsyncClient
+
+async def main() -> None:
+    client = HttpxAsyncClient()
+    resp = await client.get("https://www.skoob.com.br")
+    print(resp.text[:100])
+    await client.close()
+
+asyncio.run(main())
+```

--- a/docs/index.md
+++ b/docs/index.md
@@ -26,3 +26,8 @@ with SkoobClient() as client:
 ::: pyskoob.users
 ::: pyskoob.profile
 ::: pyskoob.publishers
+
+## Further Reading
+
+- [Advanced Usage](advanced_usage.md)
+- [Stable Public API](stable_api.md)

--- a/docs/stable_api.md
+++ b/docs/stable_api.md
@@ -1,0 +1,22 @@
+# Stable Public API
+
+The following classes and functions are considered stable. They are re-exported
+from the :mod:`pyskoob` package and will only change with a deprecation period.
+You can import them directly from the package root:
+
+```python
+from pyskoob import SkoobClient, HttpxSyncClient
+```
+
+- `SkoobClient`
+- `AuthService`
+- `BookService`
+- `AuthorService`
+- `UserService`
+- `SkoobProfileService`
+- `PublisherService`
+- `HttpxSyncClient`
+- `HttpxAsyncClient`
+
+Anything not listed above should be treated as internal and may change without
+notice.

--- a/pyskoob/__init__.py
+++ b/pyskoob/__init__.py
@@ -1,1 +1,28 @@
-"""Public API for the PySkoob package."""
+"""Public API for the PySkoob package.
+
+This module re-exports the most commonly used classes so that users can simply
+import from ``pyskoob``. Everything listed in ``__all__`` is considered stable
+and will not change without a deprecation period.
+"""
+
+from .auth import AuthService
+from .authors import AuthorService
+from .books import BookService
+from .client import SkoobClient
+from .http.httpx import HttpxAsyncClient, HttpxSyncClient
+from .profile import SkoobProfileService
+from .publishers import PublisherService
+from .users import UserService
+
+__all__ = [
+    "AuthService",
+    "AuthorService",
+    "BookService",
+    "HttpxAsyncClient",
+    "HttpxSyncClient",
+    "PublisherService",
+    "SkoobClient",
+    "SkoobProfileService",
+    "UserService",
+]
+


### PR DESCRIPTION
## Summary
- add a public API surface in `pyskoob.__init__`
- document pagination and async usage examples
- describe the stable public API with top-level import examples
- link new docs from the index
- mention new docs in the changelog

## Testing
- `ruff check --no-fix --output-format=github .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688d1f66ce5483299c6714008d60b9a5