### PR TITLE
docs: simplify README for users

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,57 +5,33 @@
 [![Python Versions](https://img.shields.io/pypi/pyversions/scraper-skoob)](https://pypi.org/project/scraper-skoob/)
 [![License](https://img.shields.io/github/license/victor-soeiro/pyskoob)](LICENSE)
 
-## Overview
-PySkoob is a Python library that simplifies interacting with the Skoob website. It acts as an HTTP client, providing services for authentication, book searches, and profile access. The goal of the project is to streamline integrations and automation while offering an easy‑to‑use interface.
+**PySkoob** is a Python client that makes it easy to interact with the Skoob website. It takes care of authentication and HTML parsing so you can focus on your automation or data collection tasks.
 
-## Documentation
-The full documentation is generated using [MkDocs](https://www.mkdocs.org/) and lives in the `docs/` folder. To preview it locally run:
+## Features
 
-```bash
-pip install -e .[docs]
-mkdocs serve
-```
+- Search books by title, author or ISBN
+- Retrieve detailed book information and reviews
+- Access user profiles and reading statistics
+- Authenticate using email/password or an existing session cookie
 
 ## Installation
-Create a virtual environment using [uv](https://github.com/astral-sh/uv) and
-install from PyPI:
+
+Install the latest release from PyPI:
 
 ```bash
-uv venv .venv
-source .venv/bin/activate
-uv pip install scraper-skoob
+python -m pip install scraper-skoob
 ```
 
-To always use the latest version from GitHub:
+Or install the bleeding edge version from GitHub:
 
 ```bash
-uv pip install git+https://github.com/victor-soeiro/pyskoob.git
+python -m pip install git+https://github.com/victor-soeiro/pyskoob.git
 ```
 
-## Authentication
-You can authenticate in two different ways:
+## Usage examples
 
-1. **Email and password**
+### Search for books
 
-    ```python
-    from pyskoob.client import SkoobClient
-
-    with SkoobClient() as client:
-        me = client.auth.login(email="you@example.com", password="secret")
-    ```
-
-2. **Session cookie**
-
-    ```python
-    from pyskoob.client import SkoobClient
-
-    with SkoobClient() as client:
-        me = client.auth.login_with_cookies("PHPSESSID_TOKEN")
-    ```
-
-Once authenticated you can access all other services.
-
-## Usage example
 ```python
 from pyskoob.client import SkoobClient
 from pyskoob.models.enums import BookSearch
@@ -66,42 +42,29 @@ with SkoobClient() as client:
         print(book.title, book.book_id)
 ```
 
-## Running tests
-Install the project in editable mode and run the test suite:
+### Fetch book details
 
-```bash
-uv pip install -e .
-pytest -vv
+```python
+from pyskoob.client import SkoobClient
+
+with SkoobClient() as client:
+    book = client.books.get_by_id(1)  # replace with a real edition ID
+    print(book.title, book.publisher.name)
 ```
 
-Generate a coverage report with:
+### Authenticate and access your profile
 
-```bash
-pytest --cov=pyskoob
+```python
+from pyskoob.client import SkoobClient
+
+with SkoobClient() as client:
+    # TIP: use environment variables or a secrets manager instead of hard-coding credentials
+    me = client.auth.login(email="you@example.com", password="secret")
+    print(me.name)
 ```
 
-## Contributing
-1. Fork the repository and create a branch for your feature.
-2. Install the dependencies in editable mode:
+## Learn more
 
-   ```bash
-   uv pip install -e .
-   ```
-3. Implement your change and add tests.
-4. Run `ruff` to check code style:
-
-   ```bash
-   ruff .
-   ```
-5. Run `pytest` and ensure everything passes.
-6. Open a pull request describing your changes.
-
-Contributions are very welcome!
-
-## Documentation
-The full project documentation is automatically published using [GitHub Pages](https://pages.github.com/).
-Our workflow builds the site on every push or pull request but only deploys on pushes to the `main` branch. The generated files are pushed to the `gh-pages` branch using the official **GitHub Pages** action. Make sure the repository Pages settings are configured with **GitHub Actions** as the source, otherwise GitHub will render the repository README instead of the site.
-
-The published site is available at:
-
-https://victor-soeiro.github.io/pyskoob/
+- [Examples](examples)
+- [Documentation](https://victor-soeiro.github.io/pyskoob/)
+- [Contributing guidelines](CONTRIBUTING.md)


### PR DESCRIPTION
## Summary
- restructure README around practical usage examples
- link to docs and contributing guidelines instead of inlining development steps

## Testing
- `ruff check .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688d1b542e14832981e1bc8a7f452cbe