### PR TITLE
chore: configure version bumping

### DIFF
--- a/.bumpversion.toml
+++ b/.bumpversion.toml
@@ -1,0 +1,14 @@
+[tool.bumpversion]
+current_version = "0.1.1"
+parse = "(?P<major>\\d+)\\.(?P<minor>\\d+)\\.(?P<patch>\\d+)"
+serialize = ["{major}.{minor}.{patch}"]
+
+[[tool.bumpversion.files]]
+filename = "pyproject.toml"
+search = "version = \"{current_version}\""
+replace = "version = \"{new_version}\""
+
+[[tool.bumpversion.files]]
+filename = "pyskoob/__init__.py"
+search = "__version__ = \"{current_version}\""
+replace = "__version__ = \"{new_version}\""

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "scraper-skoob"
-version = "0.1.0"
+version = "0.1.1"
 description = "Add your description here"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/pyskoob/__init__.py
+++ b/pyskoob/__init__.py
@@ -5,6 +5,8 @@ import from ``pyskoob``. Everything listed in ``__all__`` is considered stable
 and will not change without a deprecation period.
 """
 
+__version__ = "0.1.1"
+
 from .auth import AuthService
 from .authors import AuthorService
 from .books import BookService
@@ -25,5 +27,6 @@ __all__ = [
     "SkoobClient",
     "SkoobProfileService",
     "UserService",
-    "ParsingError"
+    "ParsingError",
+    "__version__",
 ]


### PR DESCRIPTION
## Summary
- expose package version via `__version__`
- add bump-my-version configuration and bump to 0.1.1

## Testing
- `ruff check .`
- `PYTHONPATH=. pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688d7a9e4aa88329b49e194b04f8b44f