### PR TITLE
fix: validate change_book_shelf response

### DIFF
--- a/pyskoob/profile.py
+++ b/pyskoob/profile.py
@@ -160,7 +160,7 @@ class SkoobProfileService(BaseSkoobService):
         Returns
         -------
         bool
-            True if the bookshelf was changed successfully.
+            True if the bookshelf was changed successfully, False otherwise.
 
         Examples
         --------
@@ -171,7 +171,7 @@ class SkoobProfileService(BaseSkoobService):
         url = f"{self.base_url}/estante/prateleira/{edition_id}/{bookshelf.value}"
         response = self.client.get(url)
         response.raise_for_status()
-        return True
+        return response.json().get("success", False)
 
     def rate_book(self, edition_id: int, ranking: float) -> bool:
         """

--- a/tests/test_profile_service.py
+++ b/tests/test_profile_service.py
@@ -71,3 +71,8 @@ def test_label_and_status_methods():
     assert service.remove_book_status(1)
     assert service.change_book_shelf(1, BookShelf.BOOK)
     assert client.called  # ensure requests were made
+
+
+def test_change_book_shelf_failure():
+    service, _ = make_service(False)
+    assert service.change_book_shelf(1, BookShelf.BOOK) is False


### PR DESCRIPTION
## Summary
- ensure `change_book_shelf` returns API success value
- test failure case for `change_book_shelf`

## Testing
- `ruff check pyskoob/profile.py tests/test_profile_service.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_688d7ecc97288329b3fb32e382964ac9