### PR TITLE
ci: grant push permission for version bump workflow

### DIFF
--- a/.github/workflows/version-bump.yml
+++ b/.github/workflows/version-bump.yml
@@ -5,6 +5,9 @@ on:
     branches:
       - main
 
+permissions:
+  contents: write
+
 jobs:
   bump:
     if: github.actor != 'github-actions[bot]'


### PR DESCRIPTION
## Summary
- allow version bump workflow to push commits and tags

## Testing
- `ruff check .`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_688d8256ed7483298a7a6f1a1311a72d

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated workflow configuration to ensure proper permissions for automated version bump process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->