### PR TITLE
chore: restrict version bump workflow permissions

### DIFF
--- a/.github/workflows/version-bump.yml
+++ b/.github/workflows/version-bump.yml
@@ -5,13 +5,12 @@ on:
     branches:
       - main
 
-permissions:
-  contents: write
-
 jobs:
   bump:
     if: github.actor != 'github-actions[bot]'
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     concurrency:
       group: version-bump-${{ github.ref }}
       cancel-in-progress: false


### PR DESCRIPTION
## Summary
- reduce permissions scope for version bump workflow

## Testing
- `ruff check .`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_688d8adca4e48329ba411631f99591fe

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated workflow configuration for improved permission management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->