### PR TITLE
fix: build package before publishing to PyPI

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,6 +29,10 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: '3.11'
+      - name: Build package
+        run: |
+          python -m pip install build
+          python -m build
       - name: Publish to PyPI
         uses: pypa/gh-action-pypi-publish@v1.8.11
         with:


### PR DESCRIPTION
## Summary
- build package before invoking PyPI publish action so distribution files exist

## Testing
- `ruff check .`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_688d8bb3b684832986690e6932d8c096