### PR TITLE
fix: trigger release workflow after version bump

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,19 +1,30 @@
 name: Create Release Draft
 on:
-  push:
-    tags:
-      - 'v*.*.*'
+  workflow_run:
+    workflows: ["Bump Version"]
+    types:
+      - completed
 jobs:
   release:
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
     runs-on: ubuntu-latest
+    outputs:
+      tag: ${{ steps.tag.outputs.tag }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.workflow_run.head_sha }}
+          fetch-depth: 0
+      - name: Determine tag
+        id: tag
+        run: echo "tag=$(git describe --tags --abbrev=0)" >> "$GITHUB_OUTPUT"
       - name: Create release draft
         uses: softprops/action-gh-release@v2
         with:
           draft: true
           generate_release_notes: true
+          tag_name: ${{ steps.tag.outputs.tag }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
@@ -25,10 +36,17 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          ref: ${{ needs.release.outputs.tag }}
+          fetch-depth: 0
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
           python-version: '3.11'
+      - name: Build package
+        run: |
+          python -m pip install build
+          python -m build
       - name: Publish to PyPI
         uses: pypa/gh-action-pypi-publish@v1.8.11
         with:


### PR DESCRIPTION
## Summary
- trigger release workflow after Bump Version workflow completes
- build package before invoking PyPI publish action so distribution files exist

## Testing
- `pip install -e .`
- `ruff check .`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_688d8bb3b684832986690e6932d8c096