### PR TITLE
fix: update PyPI publish action

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -50,7 +50,7 @@ jobs:
           python -m pip install build
           python -m build
       - name: Publish to PyPI
-        uses: pypa/gh-action-pypi-publish@v1.8.11
+        uses: pypa/gh-action-pypi-publish@release/v1
         with:
           password: ${{ secrets.PYPI_API_TOKEN }}
           skip-existing: true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) 
 - List of stable public API exports.
 ### Fixed
 - Avoided ``httpx`` deprecation warning when posting raw bytes or text.
+- Updated PyPI publish workflow to use the latest action release, resolving missing metadata errors.
 
 ### Changed
 - Removed the standalone lint workflow and moved Ruff earlier in the CI job.


### PR DESCRIPTION
## Summary
- use latest pypi publish action to fix missing metadata error
- document release workflow fix in changelog

## Testing
- `ruff check .`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_688e9b18e61883298b8c4d3fb31f993b

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the workflow for publishing Python packages to PyPI to use the latest release of the publish action, improving reliability.
  * Added a changelog entry documenting the workflow update.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->