### PR TITLE
ci: add permissions and caching

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,9 @@ on:
   push:
   pull_request:
 
+permissions:
+  contents: read
+
 jobs:
   lint:
     runs-on: ubuntu-latest
@@ -19,6 +22,14 @@ jobs:
 
       - name: Set up uv
         uses: astral-sh/setup-uv@v6
+
+      - name: Cache dependencies
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/uv
+          key: ${{ runner.os }}-uv-${{ hashFiles('uv.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-uv-
 
       - name: Install ruff
         run: uv pip install --system ruff
@@ -44,6 +55,14 @@ jobs:
 
       - name: Set up uv
         uses: astral-sh/setup-uv@v6
+
+      - name: Cache dependencies
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/uv
+          key: ${{ runner.os }}-uv-${{ hashFiles('uv.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-uv-
 
       - name: Install ruff
         if: matrix.python-version == '3.12'


### PR DESCRIPTION
## Summary
- restrict CI workflow token to read-only content access
- cache uv dependencies to accelerate lint and test jobs

## Testing
- `ruff check --diff`
- `uv pip install --system -e .[dev]`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_688e9cc3c294832988e4864efb291ca5