### PR TITLE
ci: enable coverage reporting

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,5 +60,11 @@ jobs:
       - name: Install dependencies
         run: uv pip install --system -e .[dev]
 
-      - name: Run tests
-        run: pytest
+      - name: Run tests with coverage
+        run: pytest --cov --cov-report=xml
+
+      - name: Upload coverage report
+        uses: actions/upload-artifact@v4
+        with:
+          name: coverage-${{ matrix.python-version }}
+          path: coverage.xml


### PR DESCRIPTION
## Summary
- run pytest with coverage and upload coverage report artifact

## Testing
- `ruff check .`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_688e9c97391c8329a9af7195044ae54f