### PR TITLE
ci: pin Ruff version in lint workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ jobs:
         uses: astral-sh/setup-uv@v6
 
       - name: Install ruff
-        run: uv pip install --system ruff
+        run: uv pip install --system "ruff==0.4.5"
 
       - name: Lint with ruff
         run: ruff check --no-fix --output-format=github .


### PR DESCRIPTION
## Summary
- pin Ruff to version 0.4.5 in lint job to match test job

## Testing
- `ruff check .`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_688e9c9f4d008329bdd430c4c38e16ec