### PR TITLE
chore: minimize release workflow permissions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,9 +5,11 @@ on:
     types:
       - completed
 permissions:
-  contents: write
+  contents: read
 jobs:
   release:
+    permissions:
+      contents: write
     if: ${{ github.event.workflow_run.conclusion == 'success' }}
     runs-on: ubuntu-latest
     outputs:


### PR DESCRIPTION
## Summary
- limit default release workflow token to read-only
- grant write permission only to the release job

## Testing
- `ruff check .`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_688e9ccd9ca08329b21e0233b7ab0591