### PR TITLE
ci: restrict docs deployment to main branch

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -42,6 +42,7 @@ jobs:
           path: ./site
 
   deploy-docs:
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
     needs: build-docs
     runs-on: ubuntu-latest
     permissions:


### PR DESCRIPTION
## Summary
- ensure docs deploy only on pushes to main branch

## Testing
- `ruff check .`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_688e9cec6108832983665e724dee705d