### PR TITLE
docs: add security policy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) 
 - Example script demonstrating AuthorService usage.
 - Documentation for pagination and asynchronous usage examples.
 - List of stable public API exports.
+- Security policy describing vulnerability reporting and secret management.
 ### Fixed
 - Avoided ``httpx`` deprecation warning when posting raw bytes or text.
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,25 @@
+# Security Policy
+
+## Reporting a Vulnerability
+
+If you discover a security issue, please report it responsibly to help us keep the community safe.
+
+- Use the "Report a vulnerability" feature under the GitHub **Security** tab for this repository.
+- Alternatively, send a private email to the maintainers at the address listed in the repository profile.
+- Please do not open public issues for security problems.
+
+We will review your report promptly and work with you to validate and resolve the issue.
+
+## Secret Management
+
+Follow these practices to avoid leaking secrets:
+
+- Never commit passwords, API keys, or other credentials to the repository.
+- Use environment variables or a dedicated secrets manager for sensitive data.
+- Rotate credentials regularly and revoke any leaked keys immediately.
+- Remove secrets from logs, commits, and issue descriptions.
+
+## Supported Versions
+
+Security fixes are applied to the latest release. Older versions may not receive patches; upgrade to the newest version to stay secure.
+


### PR DESCRIPTION
## Summary
- add SECURITY policy with vulnerability disclosure and secret management guidelines
- note new security policy in changelog

## Testing
- `ruff check .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688e9d038a6c8329bffbdfc0f4eaf123