### PR TITLE
refactor: annotate context manager return types

### DIFF
--- a/pyskoob/client.py
+++ b/pyskoob/client.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from pyskoob.auth import AuthService
 from pyskoob.authors import AuthorService
 from pyskoob.books import BookService
@@ -28,7 +30,7 @@ class SkoobClient:
         self.me = SkoobProfileService(self._client, self.auth)
         self.publishers = PublisherService(self._client)
 
-    def __enter__(self):
+    def __enter__(self) -> SkoobClient:
         """
         Enter the runtime context for the SkoobClient.
 
@@ -44,7 +46,7 @@ class SkoobClient:
         """
         return self
 
-    def __exit__(self, exc_type, exc_val, exc_tb):
+    def __exit__(self, exc_type, exc_val, exc_tb) -> None:
         """
         Exit the runtime context, closing the HTTPX client.
 


### PR DESCRIPTION
## Summary
- annotate `SkoobClient.__enter__` and `__exit__` with explicit return types for clearer context manager usage

## Testing
- `ruff check pyskoob/client.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_688e9d44a5448329b277976fc451cdf0