### PR TITLE
chore: restrict release workflow to main branch

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,6 +2,7 @@ name: Create Release Draft
 on:
   workflow_run:
     workflows: ["Bump Version"]
+    branches: [main]
     types:
       - completed
 permissions:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) 
 - Removed the standalone lint workflow and moved Ruff earlier in the CI job.
 - Added a dedicated step to install Ruff before running linting.
 - Fixed installation command for Ruff to target the system environment.
+- Restricted the release workflow to run only after the Bump Version workflow succeeds on the `main` branch.
 
 ## [0.1.0] - 2025-07-30
 ### Added


### PR DESCRIPTION
## Summary
- restrict release workflow to run only after Bump Version on main branch
- document branch restriction in changelog

## Testing
- `ruff check .`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_688e9cda3eb483299fba23b6889b7ac0