### PR TITLE
chore: update package name references

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # PySkoob
 
-[![PyPI](https://img.shields.io/pypi/v/scraper-skoob?color=blue)](https://pypi.org/project/scraper-skoob/)
+[![PyPI](https://img.shields.io/pypi/v/pyskoob?color=blue)](https://pypi.org/project/pyskoob/)
 [![CI](https://github.com/victor-soeiro/pyskoob/actions/workflows/ci.yml/badge.svg)](https://github.com/victor-soeiro/pyskoob/actions/workflows/ci.yml)
-[![Python Versions](https://img.shields.io/pypi/pyversions/scraper-skoob)](https://pypi.org/project/scraper-skoob/)
+[![Python Versions](https://img.shields.io/pypi/pyversions/pyskoob)](https://pypi.org/project/pyskoob/)
 [![License](https://img.shields.io/github/license/victor-soeiro/pyskoob)](LICENSE)
 
 **PySkoob** is a Python client that makes it easy to interact with the Skoob website. It takes care of authentication and HTML parsing so you can focus on your automation or data collection tasks.
@@ -19,7 +19,7 @@
 Install the latest release from PyPI:
 
 ```bash
-python -m pip install scraper-skoob
+python -m pip install pyskoob
 ```
 
 Or install the bleeding edge version from GitHub:

--- a/docs/index.md
+++ b/docs/index.md
@@ -5,7 +5,7 @@ Welcome to the **PySkoob** documentation. This site provides usage examples and 
 ## Installation
 
 ```bash
-pip install scraper-skoob
+pip install pyskoob
 ```
 
 ## Usage

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [project]
-name = "scraper-skoob"
+name = "pyskoob"
 version = "0.1.10"
 description = "Add your description here"
 readme = "README.md"

--- a/uv.lock
+++ b/uv.lock
@@ -7,7 +7,7 @@ anyio==4.9.0
 beautifulsoup4==4.13.4
     # via bs4
 bs4==0.0.2
-    # via scraper-skoob (pyproject.toml)
+    # via pyskoob (pyproject.toml)
 certifi==2025.7.14
     # via
     #   httpcore
@@ -22,7 +22,7 @@ h11==0.16.0
 httpcore==1.0.9
     # via httpx
 httpx==0.28.1
-    # via scraper-skoob (pyproject.toml)
+    # via pyskoob (pyproject.toml)
 idna==3.10
     # via
     #   anyio
@@ -37,21 +37,21 @@ pluggy==1.6.0
     #   pytest
     #   pytest-cov
 pydantic==2.11.7
-    # via scraper-skoob (pyproject.toml)
+    # via pyskoob (pyproject.toml)
 pydantic-core==2.33.2
     # via pydantic
 pygments==2.19.2
     # via pytest
 pytest==8.4.1
     # via
-    #   scraper-skoob (pyproject.toml)
+    #   pyskoob (pyproject.toml)
     #   pytest-cov
 pytest-cov==6.2.1
-    # via scraper-skoob (pyproject.toml)
+    # via pyskoob (pyproject.toml)
 requests==2.32.4
-    # via scraper-skoob (pyproject.toml)
+    # via pyskoob (pyproject.toml)
 ruff==0.12.7
-    # via scraper-skoob (pyproject.toml)
+    # via pyskoob (pyproject.toml)
 sniffio==1.3.1
     # via anyio
 soupsieve==2.7


### PR DESCRIPTION
## Summary
- rename project package from `scraper-skoob` to `pyskoob`
- refresh lock file and documentation

## Testing
- `ruff format .`
- `ruff check .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688ebc36dbc08329b6ad80a59e7dc0b4

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated all references in the README and documentation to use the new package name "pyskoob" instead of "scraper-skoob".
  * Corrected installation instructions to reflect the new package name.

* **Chores**
  * Changed the project name in configuration files from "scraper-skoob" to "pyskoob".

<!-- end of auto-generated comment: release notes by coderabbit.ai -->