### PR TITLE
chore: add pre-commit hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,15 @@
+repos:
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.12.7
+    hooks:
+      - id: ruff
+        args: [--fix, --exit-non-zero-on-fix]
+      - id: ruff-format
+  - repo: local
+    hooks:
+      - id: pytest
+        name: pytest
+        entry: pytest
+        language: system
+        types: [python]
+        pass_filenames: false

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) 
 - Example script demonstrating AuthorService usage.
 - Documentation for pagination and asynchronous usage examples.
 - List of stable public API exports.
+- Pre-commit configuration for Ruff, formatting and tests.
 ### Fixed
 - Avoided ``httpx`` deprecation warning when posting raw bytes or text.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -25,15 +25,14 @@ source .venv/bin/activate
 # Install dependencies in editable mode
 uv pip install -e .[dev]
 
-# Run the test suite
-pytest -q
+# Install pre-commit hooks
+pre-commit install
 
-# Format the code and run the linter
-ruff format .
-ruff check .
+# Run all checks
+pre-commit run --all-files
 ```
 
-Run `ruff format .` to automatically fix formatting issues. The CI workflow uses `ruff format --check .` to ensure files are already formatted.
+Run `pre-commit run --all-files` to ensure formatting, linting and tests pass locally. The CI workflow runs the same hooks to verify submitted changes.
 
 Open your PR on GitHub and fill in a brief summary of your changes. A maintainer will review it as soon as possible.
 


### PR DESCRIPTION
## Summary
- add pre-commit configuration running ruff, formatter, and tests
- document pre-commit usage in contributing guide
- record pre-commit setup in changelog

## Testing
- `ruff format --check .`
- `ruff check .`
- `pre-commit run --all-files`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688e9d11f9e08329afbd04d0efd9c625