### PR TITLE
refactor: standardize workflow names

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,4 @@
-name: CI
+name: Continuous Integration
 
 # Run lint and tests on each push and pull request
 on:

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,4 +1,4 @@
-name: Docs
+name: Documentation Build and Deployment
 
 on:
   push:
@@ -44,6 +44,7 @@ jobs:
   deploy-docs:
     needs: build-docs
     runs-on: ubuntu-latest
+    if: github.event_name == 'push'
     permissions:
       contents: write
       pages: write

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,7 +1,7 @@
-name: Create Release Draft
+name: Draft Release and Publish to PyPI
 on:
   workflow_run:
-    workflows: ["Bump Version"]
+    workflows: ["Automated Version Bump"]
     branches: [main]
     types:
       - completed

--- a/.github/workflows/version-bump.yml
+++ b/.github/workflows/version-bump.yml
@@ -1,4 +1,4 @@
-name: Bump Version
+name: Automated Version Bump
 
 on:
   push:


### PR DESCRIPTION
## Summary
- rename ci workflow to Continuous Integration
- rename docs workflow to Documentation Build and Deployment
- rename version-bump workflow to Automated Version Bump
- rename release workflow to Draft Release and Publish to PyPI and update dependency
- restrict docs deployment to push events

## Testing
- `ruff check .`
- `pip install -e .[dev]`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_688ebcb4fab48329a1b042503529bc96