### PR TITLE
Add workflow to delete Codex branches after merge

### DIFF
--- a/.github/workflows/delete-codex-branches.yml
+++ b/.github/workflows/delete-codex-branches.yml
@@ -1,0 +1,23 @@
+name: Delete Codex Branches
+
+on:
+  pull_request:
+    types: [closed]
+
+jobs:
+  delete:
+    if: github.event.pull_request.merged == true && startsWith(github.event.pull_request.head.ref, 'codex/')
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Delete branch
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            await github.rest.git.deleteRef({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              ref: `heads/${context.payload.pull_request.head.ref}`
+            });


### PR DESCRIPTION
## Description
Adds a GitHub Action that removes branches with the `codex/` prefix once their pull requests are merged.

## Motivation and Context
Keeps the repository tidy by automatically cleaning up Codex feature branches after their corresponding pull requests are merged.

## How Has This Been Tested?
- `pre-commit run --files .github/workflows/delete-codex-branches.yml`
- `pytest`

## Checklist
- [x] Code follows project style guidelines
- [x] Lint and tests pass locally
- [ ] Documentation has been updated if necessary

Closes #

------
https://chatgpt.com/codex/tasks/task_e_688ec2ea51248329b9b2cd6f5eced966