### PR TITLE
refactor: use parameterized logging in AuthService

### DIFF
--- a/pyskoob/auth.py
+++ b/pyskoob/auth.py
@@ -52,7 +52,7 @@ class AuthService(BaseSkoobService):
         self.client.cookies.update({"PHPSESSID": session_token})
         user = self.get_my_info()
         self._is_logged_in = True
-        logger.info(f"Successfully logged in as user: '{user.name}'")
+        logger.info("Successfully logged in as user: '%s'", user.name)
         return user
 
     def login(self, email: str, password: str) -> User:
@@ -138,7 +138,7 @@ class AuthService(BaseSkoobService):
         user_data = json_data["response"]
         user_data["profile_url"] = self.base_url + user_data["url"]  # patch field for alias
         user = User.model_validate(user_data)
-        logger.info(f"Successfully retrieved user: '{user.name}'")
+        logger.info("Successfully retrieved user: '%s'", user.name)
         return user
 
     def validate_login(self) -> None:


### PR DESCRIPTION
## Summary
- refactor logging in AuthService to use parameterized messages

## Testing
- `ruff check .`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_688ec3db0a5083299b70629550e8123a