### PR TITLE
refactor: handle specific exceptions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) 
 - Introduced ``HTTPClientError`` and moved HTTP error handling to the client layer to avoid ``httpx`` coupling.
 - Preserved ``HTTPClientError`` propagation in book services and aligned user search error handling.
 - Propagated ``HTTPClientError`` in publisher service to maintain error specificity.
+- Allowed user search HTTP errors to propagate as ``HTTPClientError`` for clearer diagnostics.
 
 ## [0.1.0] - 2025-07-30
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) 
 - Removed the standalone lint workflow and moved Ruff earlier in the CI job.
 - Added a dedicated step to install Ruff before running linting.
 - Fixed installation command for Ruff to target the system environment.
+- Refined exception handling to use specific exceptions and propagate meaningful errors.
+- Introduced ``HTTPClientError`` and moved HTTP error handling to the client layer to avoid ``httpx`` coupling.
+- Preserved ``HTTPClientError`` propagation in book services and aligned user search error handling.
+- Propagated ``HTTPClientError`` in publisher service to maintain error specificity.
 
 ## [0.1.0] - 2025-07-30
 ### Added

--- a/pyskoob/__init__.py
+++ b/pyskoob/__init__.py
@@ -5,11 +5,12 @@ import from ``pyskoob``. Everything listed in ``__all__`` is considered stable
 and will not change without a deprecation period.
 """
 
+from . import models
 from .auth import AuthService
 from .authors import AuthorService
 from .books import BookService
 from .client import SkoobClient
-from .exceptions import ParsingError
+from .exceptions import HTTPClientError, ParsingError
 from .http.httpx import HttpxAsyncClient, HttpxSyncClient
 from .profile import SkoobProfileService
 from .publishers import PublisherService
@@ -25,5 +26,7 @@ __all__ = [
     "SkoobClient",
     "SkoobProfileService",
     "UserService",
-    "ParsingError"
+    "HTTPClientError",
+    "ParsingError",
+    "models",
 ]

--- a/pyskoob/auth.py
+++ b/pyskoob/auth.py
@@ -98,14 +98,8 @@ class AuthService(BaseSkoobService):
             logger.error("Login response was not valid JSON")
             raise ConnectionError("Invalid response format") from exc
         if not json_data.get("success", False):
-            logger.error(
-                "Login failed: %s", json_data.get("message", "Unknown error")
-            )
-            raise ConnectionError(
-                "Failed to login: {}".format(
-                    json_data.get("message", "Unknown error")
-                )
-            )
+            logger.error("Login failed: %s", json_data.get("message", "Unknown error"))
+            raise ConnectionError("Failed to login: {}".format(json_data.get("message", "Unknown error")))
 
         self._is_logged_in = True
         user = self.get_my_info()
@@ -138,19 +132,11 @@ class AuthService(BaseSkoobService):
 
         json_data = response.json()
         if not json_data.get("success"):
-            logger.error(
-                "Failed to retrieve user information. "
-                "The session token might be invalid."
-            )
-            raise ConnectionError(
-                "Failed to retrieve user information. "
-                "The session token might be invalid."
-            )
+            logger.error("Failed to retrieve user information. The session token might be invalid.")
+            raise ConnectionError("Failed to retrieve user information. The session token might be invalid.")
 
         user_data = json_data["response"]
-        user_data["profile_url"] = (
-            self.base_url + user_data["url"]
-        )  # patch field for alias
+        user_data["profile_url"] = self.base_url + user_data["url"]  # patch field for alias
         user = User.model_validate(user_data)
         logger.info(f"Successfully retrieved user: '{user.name}'")
         return user
@@ -172,8 +158,5 @@ class AuthService(BaseSkoobService):
         logger.debug("Validating login status.")
         if not self._is_logged_in:
             logger.warning("Validation failed: User is not logged in.")
-            raise PermissionError(
-                "User is not logged in. "
-                "Please call 'login_with_cookies' first."
-            )
+            raise PermissionError("User is not logged in. Please call 'login_with_cookies' first.")
         logger.debug("Validation successful: User is logged in.")

--- a/pyskoob/books.py
+++ b/pyskoob/books.py
@@ -59,6 +59,8 @@ class BookService(BaseSkoobService):
 
         Raises
         ------
+        HTTPClientError
+            If an HTTP request fails.
         ParsingError
             If the HTML structure changes and parsing fails.
 
@@ -67,42 +69,23 @@ class BookService(BaseSkoobService):
         >>> service.search("Duna").results[0].title
         'Duna'
         """
-        url = (
-            f"{self.base_url}/livro/lista/busca:{query}/"
-            f"tipo:{search_by.value}/mpage:{page}"
-        )
-        logger.info(
-            f"Searching for books with query: '{query}' on page {page}"
-        )
+        url = f"{self.base_url}/livro/lista/busca:{query}/tipo:{search_by.value}/mpage:{page}"
+        logger.info(f"Searching for books with query: '{query}' on page {page}")
         try:
             response = self.client.get(url)
-            response.raise_for_status()
             soup = self.parse_html(response.text)
 
             limit = 30
             results: list[BookSearchResult | None] = [
-                self._parse_search_result(book_div)
-                for book_div in safe_find_all(
-                    soup, "div", {"class": "box_lista_busca_vertical"}
-                )
+                self._parse_search_result(book_div) for book_div in safe_find_all(soup, "div", {"class": "box_lista_busca_vertical"})
             ]
             cleaned_results: list[BookSearchResult] = [i for i in results if i]
 
             total_results = self._extract_total_results(soup)
             next_page_link = True if page * limit < total_results else False
         except (AttributeError, ValueError, IndexError, TypeError) as e:
-            logger.error(
-                f"Failed to parse book search results: {e}", exc_info=True
-            )
+            logger.error(f"Failed to parse book search results: {e}", exc_info=True)
             raise ParsingError("Failed to parse book search results.") from e
-        except Exception as e:
-            logger.error(
-                f"An unexpected error occurred during book search: {e}",
-                exc_info=True,
-            )
-            raise ParsingError(
-                "An unexpected error occurred during book search."
-            ) from e
 
         logger.info(
             "Found %s books on page %s, total %s results.",
@@ -136,8 +119,10 @@ class BookService(BaseSkoobService):
         ------
         FileNotFoundError
             If no book is found with the given edition_id.
+        HTTPClientError
+            If an HTTP request fails.
         ParsingError
-            If parsing or HTTP errors occur.
+            If parsing fails.
 
         Examples
         --------
@@ -148,16 +133,10 @@ class BookService(BaseSkoobService):
         url = f"{self.base_url}/v1/book/{edition_id}/stats:true"
         try:
             response = self.client.get(url)
-            response.raise_for_status()
             json_data = response.json().get("response")
             if not json_data:
-                cod_description = response.json().get(
-                    "cod_description", "No description provided."
-                )
-                error_msg = (
-                    f"No data found for edition_id {edition_id}. "
-                    f"Description: {cod_description}"
-                )
+                cod_description = response.json().get("cod_description", "No description provided.")
+                error_msg = f"No data found for edition_id {edition_id}. Description: {cod_description}"
                 logger.warning(error_msg)
                 raise FileNotFoundError(error_msg)
             self._clean_book_json_data(json_data)
@@ -170,18 +149,14 @@ class BookService(BaseSkoobService):
             return book
         except FileNotFoundError:
             raise
-        except Exception as e:
+        except (KeyError, ValueError, TypeError) as e:
             logger.error(
-                f"Error retrieving book for edition_id {edition_id}: {e}",
+                f"Failed to parse book data for edition_id {edition_id}: {e}",
                 exc_info=True,
             )
-            raise ParsingError(
-                f"Failed to retrieve book for edition_id {edition_id}."
-            ) from e
+            raise ParsingError(f"Failed to parse book data for edition_id {edition_id}.") from e
 
-    def get_reviews(
-        self, book_id: int, edition_id: int | None = None, page: int = 1
-    ) -> Pagination[BookReview]:
+    def get_reviews(self, book_id: int, edition_id: int | None = None, page: int = 1) -> Pagination[BookReview]:
         """
         Retrieves reviews for a book.
 
@@ -201,6 +176,8 @@ class BookService(BaseSkoobService):
 
         Raises
         ------
+        HTTPClientError
+            If an HTTP request fails.
         ParsingError
             If the HTML structure changes or parsing fails.
 
@@ -215,17 +192,13 @@ class BookService(BaseSkoobService):
         logger.info(f"Getting reviews for book_id: {book_id}, page: {page}")
         try:
             response = self.client.get(url)
-            response.raise_for_status()
             soup = self.parse_html(response.text)
             if edition_id is None:
                 edition_id = self._extract_edition_id_from_reviews_page(soup)
             book_reviews = [
                 review
                 for review in (
-                    self._parse_review(r, book_id, edition_id)
-                    for r in safe_find_all(
-                        soup, "div", {"id": re.compile(r"resenha\d+")}
-                    )
+                    self._parse_review(r, book_id, edition_id) for r in safe_find_all(soup, "div", {"id": re.compile(r"resenha\d+")})
                 )
                 if review is not None
             ]
@@ -233,14 +206,6 @@ class BookService(BaseSkoobService):
         except (AttributeError, ValueError, IndexError, TypeError) as e:
             logger.error(f"Failed to parse book reviews: {e}", exc_info=True)
             raise ParsingError("Failed to parse book reviews.") from e
-        except Exception as e:
-            logger.error(
-                f"An unexpected error occurred during review fetching: {e}",
-                exc_info=True,
-            )
-            raise ParsingError(
-                "An unexpected error occurred during review fetching."
-            ) from e
         logger.info(f"Found {len(book_reviews)} reviews on page {page}.")
         return Pagination[BookReview](
             results=book_reviews,
@@ -281,6 +246,8 @@ class BookService(BaseSkoobService):
 
         Raises
         ------
+        HTTPClientError
+            If an HTTP request fails.
         ParsingError
             If the HTML structure changes and parsing fails.
 
@@ -289,10 +256,7 @@ class BookService(BaseSkoobService):
         >>> service.get_users_by_status(1, BookUserStatus.READERS).results[:3]
         [1, 2, 3]
         """
-        url = (
-            f"{self.base_url}/livro/leitores/{status.value}/{book_id}/"
-            f"limit:{limit}/page:{page}"
-        )
+        url = f"{self.base_url}/livro/leitores/{status.value}/{book_id}/limit:{limit}/page:{page}"
         if edition_id:
             url += f"/edition:{edition_id}"
         logger.info(
@@ -303,24 +267,12 @@ class BookService(BaseSkoobService):
         )
         try:
             response = self.client.get(url)
-            response.raise_for_status()
             soup = self.parse_html(response.text)
             users_id = self._extract_user_ids_from_html(soup)
             next_page_link = safe_find(soup, "a", {"class": "proximo"})
         except (AttributeError, ValueError, IndexError, TypeError) as e:
-            logger.error(
-                f"Failed to parse users by status: {e}", exc_info=True
-            )
+            logger.error(f"Failed to parse users by status: {e}", exc_info=True)
             raise ParsingError("Failed to parse users by status.") from e
-        except Exception as e:
-            logger.error(
-                "An unexpected error occurred during user status fetching: %s",
-                e,
-                exc_info=True,
-            )
-            raise ParsingError(
-                "An unexpected error occurred during user status fetching."
-            ) from e
         logger.info(
             "Found %s users on page %s.",
             len(users_id),
@@ -359,9 +311,7 @@ class BookService(BaseSkoobService):
         ... )
         [1]
         """
-        users_html = safe_find_all(
-            soup, "div", {"class": "livro-leitor-container"}
-        )
+        users_html = safe_find_all(soup, "div", {"class": "livro-leitor-container"})
         users_id = []
         for user_div in users_html:
             user_link = safe_find(user_div, "a")
@@ -371,13 +321,9 @@ class BookService(BaseSkoobService):
                 if user_id:
                     users_id.append(int(user_id))
                 else:
-                    logger.warning(
-                        f"Could not extract user ID from URL: {href}"
-                    )
+                    logger.warning(f"Could not extract user ID from URL: {href}")
             else:
-                logger.warning(
-                    "Skipping user_div due to missing 'a' tag or href attribute."
-                )
+                logger.warning("Skipping user_div due to missing 'a' tag or href attribute.")
         return users_id
 
     def _extract_edition_id_from_reviews_page(self, soup) -> int | None:
@@ -405,9 +351,7 @@ class BookService(BaseSkoobService):
         ... )
         3
         """
-        menu_div = safe_find(
-            soup, "div", {"id": "pg-livro-menu-principal-container"}
-        )
+        menu_div = safe_find(soup, "div", {"id": "pg-livro-menu-principal-container"})
         menu_div_a = safe_find(menu_div, "a") if menu_div else None
         href = get_tag_attr(menu_div_a, "href")
         if href:
@@ -415,9 +359,7 @@ class BookService(BaseSkoobService):
             if extracted_edition_id:
                 return int(extracted_edition_id)
             else:
-                logger.warning(
-                    f"Could not extract edition_id from URL: {href}"
-                )
+                logger.warning(f"Could not extract edition_id from URL: {href}")
         return None
 
     def _parse_review(
@@ -454,34 +396,20 @@ class BookService(BaseSkoobService):
         ... # doctest: +ELLIPSIS
         """
         review_id_str = get_tag_attr(r, "id")
-        review_id = (
-            int(review_id_str.replace("resenha", ""))
-            if review_id_str
-            else None
-        )
+        review_id = int(review_id_str.replace("resenha", "")) if review_id_str else None
         if review_id is None:
-            logger.warning(
-                f"Skipping review due to missing or invalid ID: {get_tag_attr(r, 'id')}"
-            )
+            logger.warning(f"Skipping review due to missing or invalid ID: {get_tag_attr(r, 'id')}")
             return None
         user_link = safe_find(r, "a", {"href": re.compile(r"/usuario/")})
         user_url = get_tag_attr(user_link, "href")
         user_id = int(get_user_id_from_url(user_url)) if user_url else None
         if user_id is None:
-            logger.warning(
-                f"Skipping review {review_id} due to missing user ID."
-            )
+            logger.warning(f"Skipping review {review_id} due to missing user ID.")
             return None
         star_tag = safe_find(r, "star-rating")
-        rating = (
-            float(get_tag_attr(star_tag, "rate"))
-            if star_tag and get_tag_attr(star_tag, "rate")
-            else 0.0
-        )
+        rating = float(get_tag_attr(star_tag, "rate")) if star_tag and get_tag_attr(star_tag, "rate") else 0.0
         comment_div = safe_find(r, "div", {"id": re.compile(r"resenhac\d+")})
-        date, review_text = self._extract_review_date_and_text(
-            comment_div, review_id
-        )
+        date, review_text = self._extract_review_date_and_text(comment_div, review_id)
         return BookReview(
             review_id=review_id,
             book_id=book_id,
@@ -492,9 +420,7 @@ class BookService(BaseSkoobService):
             reviewed_at=date,
         )
 
-    def _extract_review_date_and_text(
-        self, comment_div: Tag | None, review_id: int
-    ) -> tuple[datetime | None, str]:
+    def _extract_review_date_and_text(self, comment_div: Tag | None, review_id: int) -> tuple[datetime | None, str]:
         """
         Extracts the review date and text from the comment div.
 
@@ -528,24 +454,18 @@ class BookService(BaseSkoobService):
                 try:
                     date = datetime.strptime(date_text, "%d/%m/%Y")
                 except ValueError:
-                    logger.warning(
-                        f"Could not parse date '{date_text}' for review {review_id}. Setting to None."
-                    )
+                    logger.warning(f"Could not parse date '{date_text}' for review {review_id}. Setting to None.")
             content_parts = []
             if date_span:
                 for sibling in date_span.next_siblings:
                     if isinstance(sibling, Tag):
-                        content_parts.append(
-                            sibling.get_text(separator="\n", strip=True)
-                        )
+                        content_parts.append(sibling.get_text(separator="\n", strip=True))
                     elif isinstance(sibling, str):
                         stripped_text = sibling.strip()
                         if stripped_text:
                             content_parts.append(stripped_text)
             else:
-                content_parts.append(
-                    comment_div.get_text(separator="\n", strip=True)
-                )
+                content_parts.append(comment_div.get_text(separator="\n", strip=True))
             review_text = "\n".join(filter(None, content_parts)).strip()
         return date, review_text
 
@@ -571,21 +491,17 @@ class BookService(BaseSkoobService):
         """
         container = safe_find(book_div, "a", {"class": "capa-link-item"})
         if not container:
-            logger.warning(
-                "Skipping book_div due to missing 'capa-link-item' container."
-            )
+            logger.warning("Skipping book_div due to missing 'capa-link-item' container.")
             return None
 
         title = get_tag_attr(container, "title")
-        book_url = f'{self.base_url}{get_tag_attr(container, "href")}'
+        book_url = f"{self.base_url}{get_tag_attr(container, 'href')}"
         img_url = self._extract_img_url(container)
         try:
             book_id = int(get_book_id_from_url(book_url))
             edition_id = int(get_book_edition_id_from_url(book_url))
-        except Exception:
-            logger.warning(
-                f"Skipping book_div due to invalid book/edition id in url: {book_url}"
-            )
+        except ValueError:
+            logger.warning(f"Skipping book_div due to invalid book/edition id in url: {book_url}")
             return None
 
         publisher, isbn = self._extract_publisher_and_isbn(book_div)
@@ -624,12 +540,10 @@ class BookService(BaseSkoobService):
         if container.img and isinstance(container.img, Tag):
             src = get_tag_attr(container.img, "src")
             if src and "https" in src:
-                return f'https{src.split("https")[-1].strip()}'
+                return f"https{src.split('https')[-1].strip()}"
         return ""
 
-    def _extract_publisher_and_isbn(
-        self, book_div: Tag
-    ) -> tuple[str | None, str | None]:
+    def _extract_publisher_and_isbn(self, book_div: Tag) -> tuple[str | None, str | None]:
         """
         Extracts publisher and ISBN information from a book search result div.
 
@@ -651,14 +565,8 @@ class BookService(BaseSkoobService):
         """
         detalhes2sub = safe_find(book_div, "div", {"class": "detalhes-2-sub"})
         detalhes2sub_div = detalhes2sub.div if detalhes2sub else None
-        spans = (
-            safe_find_all(detalhes2sub_div, "span") if detalhes2sub_div else []
-        )
-        cleaned_spans = [
-            text
-            for span in spans
-            if (text := span.get_text(strip=True)) and text != "|"
-        ]
+        spans = safe_find_all(detalhes2sub_div, "span") if detalhes2sub_div else []
+        cleaned_spans = [text for span in spans if (text := span.get_text(strip=True)) and text != "|"]
         isbn_pattern = re.compile(r"^\d{9,13}$|^B0[A-Z0-9]{8,}$")
         isbn: str | None = None
         publisher: str | None = None
@@ -699,9 +607,7 @@ class BookService(BaseSkoobService):
                 try:
                     return float(rating_text.replace(",", "."))
                 except ValueError:
-                    logger.warning(
-                        f"Could not parse rating '{rating_text}' for book '{title}'. Setting to None."
-                    )
+                    logger.warning(f"Could not parse rating '{rating_text}' for book '{title}'. Setting to None.")
         return None
 
     def _extract_total_results(self, soup) -> int:
@@ -752,32 +658,12 @@ class BookService(BaseSkoobService):
         ''
         """
         json_data["url"] = f"{self.base_url}{json_data['url']}"
-        json_data["isbn"] = (
-            None
-            if str(json_data.get("isbn", "0")) == "0"
-            else json_data["isbn"]
-        )
-        json_data["autor"] = (
-            None
-            if json_data.get("autor", "").lower() == "não especificado"
-            else json_data["autor"]
-        )
+        json_data["isbn"] = None if str(json_data.get("isbn", "0")) == "0" else json_data["isbn"]
+        json_data["autor"] = None if json_data.get("autor", "").lower() == "não especificado" else json_data["autor"]
         json_data["serie"] = json_data.get("serie") or None
-        json_data["volume"] = (
-            None
-            if not json_data.get("volume") or str(json_data["volume"]) == "0"
-            else str(json_data["volume"])
-        )
-        json_data["mes"] = (
-            None
-            if not json_data.get("mes") or str(json_data["mes"]).strip() == ""
-            else json_data["mes"]
-        )
+        json_data["volume"] = None if not json_data.get("volume") or str(json_data["volume"]) == "0" else str(json_data["volume"])
+        json_data["mes"] = None if not json_data.get("mes") or str(json_data["mes"]).strip() == "" else json_data["mes"]
         img_url = json_data.get("img_url", "")
-        json_data["cover_url"] = (
-            f'https{img_url.split("https")[-1].strip()}'
-            if img_url and "https" in img_url
-            else ""
-        )
+        json_data["cover_url"] = f"https{img_url.split('https')[-1].strip()}" if img_url and "https" in img_url else ""
         generos = json_data.get("generos")
         json_data["generos"] = generos if generos else None

--- a/pyskoob/exceptions.py
+++ b/pyskoob/exceptions.py
@@ -1,3 +1,9 @@
+class HTTPClientError(Exception):
+    """Custom exception for HTTP request failures."""
+
+    pass
+
+
 class ParsingError(Exception):
     """Custom exception for errors during HTML parsing."""
 

--- a/pyskoob/http/client.py
+++ b/pyskoob/http/client.py
@@ -44,9 +44,7 @@ class SyncHTTPClient(Protocol):
         """Send a GET request."""
         ...
 
-    def post(
-        self, url: str, data: Any | None = None, **kwargs: Any
-    ) -> HTTPResponse:
+    def post(self, url: str, data: Any | None = None, **kwargs: Any) -> HTTPResponse:
         """Send a POST request."""
         ...
 
@@ -71,9 +69,7 @@ class AsyncHTTPClient(Protocol):
         """Send an asynchronous GET request."""
         ...
 
-    async def post(
-        self, url: str, data: Any | None = None, **kwargs: Any
-    ) -> HTTPResponse:
+    async def post(self, url: str, data: Any | None = None, **kwargs: Any) -> HTTPResponse:
         """Send an asynchronous POST request."""
         ...
 

--- a/pyskoob/internal/base.py
+++ b/pyskoob/internal/base.py
@@ -93,6 +93,4 @@ class BaseSkoobService(BaseHttpService):
         >>> BaseSkoobService(httpx.Client())
         <BaseSkoobService ...>
         """
-        super().__init__(
-            client or HttpxSyncClient(), "https://www.skoob.com.br"
-        )
+        super().__init__(client or HttpxSyncClient(), "https://www.skoob.com.br")

--- a/pyskoob/users.py
+++ b/pyskoob/users.py
@@ -5,7 +5,7 @@ from datetime import datetime
 from bs4 import BeautifulSoup
 
 from pyskoob.auth import AuthService
-from pyskoob.exceptions import ParsingError
+from pyskoob.exceptions import HTTPClientError, ParsingError
 from pyskoob.http.client import SyncHTTPClient
 from pyskoob.internal.base import BaseSkoobService
 from pyskoob.models.book import BookReview
@@ -101,16 +101,12 @@ class UserService(BaseSkoobService):
             raise FileNotFoundError(f"User with ID {user_id} not found.")
 
         user_data = json_data["response"]
-        user_data["profile_url"] = (
-            self.base_url + user_data["url"]
-        )  # patch field for alias
+        user_data["profile_url"] = self.base_url + user_data["url"]  # patch field for alias
         user = User.model_validate(user_data)
         logger.info(f"Successfully retrieved user: '{user.name}'")
         return user
 
-    def get_relations(
-        self, user_id: int, relation: UsersRelation, page: int = 1
-    ) -> Pagination[int]:
+    def get_relations(self, user_id: int, relation: UsersRelation, page: int = 1) -> Pagination[int]:
         """
         Retrieves a user's relations (friends, followers, following).
 
@@ -140,22 +136,14 @@ class UserService(BaseSkoobService):
         """
         self._validate_login()
         url = f"{self.base_url}/{relation.value}/listar/{user_id}/page:{page}/limit:100"
-        logger.info(
-            f"Getting '{relation.value}' for user_id: {user_id}, page: {page}"
-        )
+        logger.info(f"Getting '{relation.value}' for user_id: {user_id}, page: {page}")
         response = self.client.get(url)
         response.raise_for_status()
 
         soup = self.parse_html(response.text)
         try:
-            users_html = safe_find_all(
-                soup, "div", {"class": "usuarios-mini-lista-txt"}
-            )
-            users_id = [
-                int(get_user_id_from_url(get_tag_attr(i.a, "href")))
-                for i in users_html
-                if i.find("a") and getattr(i, "a", None)
-            ]
+            users_html = safe_find_all(soup, "div", {"class": "usuarios-mini-lista-txt"})
+            users_id = [int(get_user_id_from_url(get_tag_attr(i.a, "href"))) for i in users_html if i.find("a") and getattr(i, "a", None)]
             next_page_link = safe_find(soup, "div", {"class": "proximo"})
         except (AttributeError, ValueError, IndexError) as e:
             logger.error(f"Failed to parse user relations: {e}")
@@ -166,15 +154,11 @@ class UserService(BaseSkoobService):
             results=users_id,
             limit=100,
             page=page,
-            total=len(
-                users_id
-            ),  # Placeholder, actual total is not easily available
+            total=len(users_id),  # Placeholder, actual total is not easily available
             has_next_page=bool(next_page_link),
         )
 
-    def get_reviews(
-        self, user_id: int, page: int = 1
-    ) -> Pagination[BookReview]:
+    def get_reviews(self, user_id: int, page: int = 1) -> Pagination[BookReview]:
         """
         Retrieves reviews made by a user.
 
@@ -196,9 +180,7 @@ class UserService(BaseSkoobService):
             If the HTML structure of the page changes and parsing fails.
         """
         self._validate_login()
-        url = (
-            f"{self.base_url}/estante/resenhas/{user_id}/mpage:{page}/limit:50"
-        )
+        url = f"{self.base_url}/estante/resenhas/{user_id}/mpage:{page}/limit:50"
         logger.info(f"Getting reviews for user_id: {user_id}, page: {page}")
         response = self.client.get(url)
         response.raise_for_status()
@@ -206,24 +188,16 @@ class UserService(BaseSkoobService):
         user_reviews = []
         soup = self.parse_html(response.text)
         try:
-            reviews_html = safe_find_all(
-                soup, "div", {"id": re.compile(r"resenha\d+")}
-            )
+            reviews_html = safe_find_all(soup, "div", {"id": re.compile(r"resenha\d+")})
             for review_elem in reviews_html:
-                review_id = int(
-                    get_tag_attr(review_elem, "id").replace("resenha", "")
-                )
-                book_anchor = safe_find(
-                    review_elem, "a", {"href": re.compile(r".*\d+ed\d+.html")}
-                )
+                review_id = int(get_tag_attr(review_elem, "id").replace("resenha", ""))
+                book_anchor = safe_find(review_elem, "a", {"href": re.compile(r".*\d+ed\d+.html")})
                 book_url = get_tag_attr(book_anchor, "href")
                 book_id = int(get_book_id_from_url(book_url))
                 edition_id = int(get_book_edition_id_from_url(book_url))
                 star_rating = safe_find(review_elem, "star-rating")
                 rating = float(get_tag_attr(star_rating, "rate", "0"))
-                comment = safe_find(
-                    review_elem, "div", {"id": re.compile(r"resenhac\d+")}
-                )
+                comment = safe_find(review_elem, "div", {"id": re.compile(r"resenhac\d+")})
                 date_str = get_tag_text(safe_find(comment, "span"))
                 date = None
                 if date_str:
@@ -235,11 +209,7 @@ class UserService(BaseSkoobService):
                 if comment:
                     span = safe_find(comment, "span")
                     if span:
-                        siblings = [
-                            get_tag_text(sib)
-                            for sib in span.next_siblings
-                            if hasattr(sib, "get_text")
-                        ]
+                        siblings = [get_tag_text(sib) for sib in span.next_siblings if hasattr(sib, "get_text")]
                         review_text = "\n".join(siblings).strip()
                 user_reviews.append(
                     BookReview(
@@ -262,9 +232,7 @@ class UserService(BaseSkoobService):
             results=user_reviews,
             limit=50,
             page=page,
-            total=len(
-                user_reviews
-            ),  # Placeholder, actual total is not easily available
+            total=len(user_reviews),  # Placeholder, actual total is not easily available
             has_next_page=bool(next_page_link),
         )
 
@@ -302,14 +270,10 @@ class UserService(BaseSkoobService):
             reading_speed=json_data.get("velocidade_dia"),
             ideal_reading_speed=json_data.get("velocidade_ideal"),
         )
-        logger.info(
-            f"Successfully retrieved read stats for user_id: {user_id}"
-        )
+        logger.info(f"Successfully retrieved read stats for user_id: {user_id}")
         return stats
 
-    def get_bookcase(
-        self, user_id: int, bookcase_option: BookcaseOption, page: int = 1
-    ) -> Pagination[UserBook]:
+    def get_bookcase(self, user_id: int, bookcase_option: BookcaseOption, page: int = 1) -> Pagination[UserBook]:
         """
         Retrieves a user's bookcase.
 
@@ -329,9 +293,7 @@ class UserService(BaseSkoobService):
         """
         self._validate_login()
         url = f"{self.base_url}/v1/bookcase/books/{user_id}/shelf_id:{bookcase_option.value}/page:{page}/limit:100"
-        logger.info(
-            f"Getting bookcase for user_id: {user_id}, option: '{bookcase_option.name}', page: {page}"
-        )
+        logger.info(f"Getting bookcase for user_id: {user_id}, option: '{bookcase_option.name}', page: {page}")
         response = self.client.get(url)
         response.raise_for_status()
 
@@ -360,9 +322,7 @@ class UserService(BaseSkoobService):
         return Pagination(
             limit=100,
             results=results,
-            total=len(
-                results
-            ),  # Placeholder, actual total is not easily available
+            total=len(results),  # Placeholder, actual total is not easily available
             has_next_page=bool(next_page),
             page=page,
         )
@@ -398,7 +358,7 @@ class UserService(BaseSkoobService):
         Raises
         ------
         ParsingError
-            If the HTML structure is invalid or parsing fails.
+            If an HTTP or parsing error occurs.
 
         Examples
         --------
@@ -413,12 +373,9 @@ class UserService(BaseSkoobService):
         if state:
             url += f"/uf:{state.value}"
 
-        response = self.client.get(url)
-        response.raise_for_status()
-
-        soup = BeautifulSoup(response.text, "html.parser")
-
         try:
+            response = self.client.get(url)
+            soup = BeautifulSoup(response.text, "html.parser")
             user_divs = safe_find_all(
                 soup,
                 "div",
@@ -427,9 +384,7 @@ class UserService(BaseSkoobService):
             results: list[UserSearch] = []
 
             for div in user_divs:
-                anchor = safe_find(
-                    div, "a", attrs={"href": re.compile(r"^/usuario/\d+-")}
-                )
+                anchor = safe_find(div, "a", attrs={"href": re.compile(r"^/usuario/\d+-")})
                 if not anchor:
                     continue
 
@@ -462,11 +417,7 @@ class UserService(BaseSkoobService):
 
             total_tag = safe_find(soup, "div", {"class": "contador"})
             total_text = get_tag_text(total_tag)
-            total = (
-                int(total_text.split("encontrados")[0].strip())
-                if "encontrados" in total_text
-                else 0
-            )
+            total = int(total_text.split("encontrados")[0].strip()) if "encontrados" in total_text else 0
 
             next_page = safe_find(soup, "a", {"class": "proximo"})
             has_next = next_page is not None
@@ -479,5 +430,5 @@ class UserService(BaseSkoobService):
                 has_next_page=has_next,
             )
 
-        except Exception as e:
+        except (AttributeError, ValueError, IndexError, TypeError, HTTPClientError) as e:
             raise ParsingError("Failed to parse user search results.") from e

--- a/pyskoob/users.py
+++ b/pyskoob/users.py
@@ -357,8 +357,10 @@ class UserService(BaseSkoobService):
 
         Raises
         ------
+        HTTPClientError
+            If the HTTP request fails.
         ParsingError
-            If an HTTP or parsing error occurs.
+            If the response cannot be parsed.
 
         Examples
         --------
@@ -430,5 +432,8 @@ class UserService(BaseSkoobService):
                 has_next_page=has_next,
             )
 
-        except (AttributeError, ValueError, IndexError, TypeError, HTTPClientError) as e:
-            raise ParsingError("Failed to parse user search results.") from e
+        except HTTPClientError as exc:  # pragma: no cover - network
+            logger.error("HTTP error searching users: %s", exc, exc_info=True)
+            raise
+        except (AttributeError, ValueError, IndexError, TypeError) as exc:
+            raise ParsingError("Failed to parse user search results.") from exc

--- a/pyskoob/utils/bs4_utils.py
+++ b/pyskoob/utils/bs4_utils.py
@@ -4,9 +4,7 @@ from bs4 import BeautifulSoup, Tag
 from bs4.element import PageElement
 
 
-def safe_find(
-    soup: BeautifulSoup | Tag | None, name: str, attrs: dict | None = None
-) -> Tag | None:
+def safe_find(soup: BeautifulSoup | Tag | None, name: str, attrs: dict | None = None) -> Tag | None:
     """
     Safely finds a single Tag in a BeautifulSoup object.
 
@@ -37,9 +35,7 @@ def safe_find(
     return None
 
 
-def safe_find_all(
-    soup: BeautifulSoup | Tag | None, name: str, attrs: dict | None = None
-) -> list[Tag]:
+def safe_find_all(soup: BeautifulSoup | Tag | None, name: str, attrs: dict | None = None) -> list[Tag]:
     """
     Safely finds all Tags in a BeautifulSoup object.
 

--- a/tests/test_book_helpers.py
+++ b/tests/test_book_helpers.py
@@ -50,10 +50,7 @@ def test_extract_user_ids_and_edition_id():
     ids = service._extract_user_ids_from_html(soup)
     assert ids == [1, 2]
 
-    html_reviews = (
-        "<div id='pg-livro-menu-principal-container'>"
-        "<a href='/livro/10-ed5.html'></a></div>"
-    )
+    html_reviews = "<div id='pg-livro-menu-principal-container'><a href='/livro/10-ed5.html'></a></div>"
     soup = BeautifulSoup(html_reviews, "html.parser")
     edition = service._extract_edition_id_from_reviews_page(soup)
     assert edition == 5

--- a/tests/test_bs4_utils.py
+++ b/tests/test_bs4_utils.py
@@ -5,21 +5,21 @@ from pyskoob.utils import bs4_utils
 
 def test_safe_find_and_find_all():
     html = '<div><span id="x">Hi</span><span>Bye</span></div>'
-    soup = BeautifulSoup(html, 'html.parser')
-    result = bs4_utils.safe_find(soup, 'span', {'id': 'x'})
+    soup = BeautifulSoup(html, "html.parser")
+    result = bs4_utils.safe_find(soup, "span", {"id": "x"})
     assert result is not None
-    assert result.text == 'Hi'
-    assert bs4_utils.safe_find(None, 'span') is None
+    assert result.text == "Hi"
+    assert bs4_utils.safe_find(None, "span") is None
 
-    spans = bs4_utils.safe_find_all(soup, 'span')
+    spans = bs4_utils.safe_find_all(soup, "span")
     assert len(spans) == 2
-    assert bs4_utils.safe_find_all(None, 'div') == []
+    assert bs4_utils.safe_find_all(None, "div") == []
 
 
 def test_get_tag_text_and_attr():
-    soup = BeautifulSoup('<a href="/foo">Link</a>', 'html.parser')
+    soup = BeautifulSoup('<a href="/foo">Link</a>', "html.parser")
     link = soup.a
-    assert bs4_utils.get_tag_text(link) == 'Link'
-    assert bs4_utils.get_tag_text(None) == ''
-    assert bs4_utils.get_tag_attr(link, 'href') == '/foo'
-    assert bs4_utils.get_tag_attr(None, 'href', 'default') == 'default'
+    assert bs4_utils.get_tag_text(link) == "Link"
+    assert bs4_utils.get_tag_text(None) == ""
+    assert bs4_utils.get_tag_attr(link, "href") == "/foo"
+    assert bs4_utils.get_tag_attr(None, "href", "default") == "default"

--- a/tests/test_imports.py
+++ b/tests/test_imports.py
@@ -2,15 +2,15 @@ import importlib
 
 # Ensure the main library modules can be imported.
 modules = [
-    'pyskoob.client',
-    'pyskoob.auth',
-    'pyskoob.books',
-    'pyskoob.users',
-    'pyskoob.profile',
-    'pyskoob.http.client',
-    'pyskoob.http.httpx',
-    'pyskoob.utils.bs4_utils',
-    'pyskoob.utils.skoob_parser_utils',
+    "pyskoob.client",
+    "pyskoob.auth",
+    "pyskoob.books",
+    "pyskoob.users",
+    "pyskoob.profile",
+    "pyskoob.http.client",
+    "pyskoob.http.httpx",
+    "pyskoob.utils.bs4_utils",
+    "pyskoob.utils.skoob_parser_utils",
 ]
 
 for mod in modules:

--- a/tests/test_profile_service.py
+++ b/tests/test_profile_service.py
@@ -1,4 +1,3 @@
-
 from typing import cast
 
 import pytest
@@ -36,11 +35,9 @@ class DummyClient:
 
 
 def make_service(success=True):
-    client = DummyClient({'success': success})
+    client = DummyClient({"success": success})
     return (
-        SkoobProfileService(
-            cast(SyncHTTPClient, client), cast(AuthService, DummyAuth())
-        ),
+        SkoobProfileService(cast(SyncHTTPClient, client), cast(AuthService, DummyAuth())),
         client,
     )
 

--- a/tests/test_public_api.py
+++ b/tests/test_public_api.py
@@ -5,4 +5,3 @@ def test_root_imports():
     assert hasattr(pyskoob, "SkoobClient")
     assert hasattr(pyskoob, "models")
     assert hasattr(pyskoob, "ParsingError")
-

--- a/tests/test_publisher_service.py
+++ b/tests/test_publisher_service.py
@@ -11,11 +11,14 @@ class DummyClient:
 
     def get(self, url: str, **_: str):
         self.called.append(url)
+
         class R:
             def __init__(self, t: str):
                 self.text = t
+
             def raise_for_status(self):
                 pass
+
         return R(self.text)
 
     def close(self):  # pragma: no cover - simple stub
@@ -55,18 +58,14 @@ def test_get_by_id():
 
 
 def test_get_authors_and_books():
-    authors_html = (
-        "<div class='box_autor'><a href='/a1'><img src='a.jpg'></a><h3>A</h3></div>"
-        "<div class='proximo'></div>"
-    )
+    authors_html = "<div class='box_autor'><a href='/a1'><img src='a.jpg'></a><h3>A</h3></div><div class='proximo'></div>"
     service, client = make_service(authors_html)
     res = service.get_authors(1)
     assert res.results[0].name == "A"
     assert res.has_next_page is True
 
     books_html = (
-        "<div class='box_livro'><a class='capa-link-item' href='/b1' title='B'><img src='b.jpg'></a></div>"
-        "<div class='proximo'></div>"
+        "<div class='box_livro'><a class='capa-link-item' href='/b1' title='B'><img src='b.jpg'></a></div><div class='proximo'></div>"
     )
     client.text = books_html
     books = service.get_books(1)

--- a/tests/test_skoob_book_service.py
+++ b/tests/test_skoob_book_service.py
@@ -12,7 +12,7 @@ from pyskoob.models.enums import BookUserStatus
 
 
 class DummyClient:
-    def __init__(self, text='', json_data=None):
+    def __init__(self, text="", json_data=None):
         self.text = text
         self.json_data = json_data or {}
         self.called = []
@@ -28,31 +28,31 @@ class DummyClient:
         return self.json_data
 
 
-def make_service(html='', json_data=None):
+def make_service(html="", json_data=None):
     client = DummyClient(text=html, json_data=json_data)
     return BookService(cast(SyncHTTPClient, client)), client
 
 
 def test_extract_helpers():
-    html = '''<div class="book">
+    html = """<div class="book">
         <a class="capa-link-item" title="T" href="/book/1-titleed2.html"><img src="https://img/x.jpg"></a>
         <div class="detalhes-2-sub"><div><span>1234567890123</span><span>Pub</span></div></div>
         <div class="star-mini"><strong>4,0</strong></div>
-    </div>'''
-    soup = BeautifulSoup(html, 'html.parser')
+    </div>"""
+    soup = BeautifulSoup(html, "html.parser")
     service, _ = make_service()
     book_div = soup.div
     assert book_div is not None
     result = service._parse_search_result(book_div)
     assert result is not None
-    assert result.title == 'T'
+    assert result.title == "T"
     assert result.edition_id == 2
-    assert result.publisher == 'Pub'
-    assert result.isbn == '1234567890123'
-    assert service._extract_rating(book_div, 'T') == 4.0
+    assert result.publisher == "Pub"
+    assert result.isbn == "1234567890123"
+    assert service._extract_rating(book_div, "T") == 4.0
     total_html = BeautifulSoup(
         '<div class="contador">3 encontrados</div>',
-        'html.parser',
+        "html.parser",
     )
     assert service._extract_total_results(total_html) == 3
 
@@ -60,35 +60,35 @@ def test_extract_helpers():
 def test_clean_book_json_data():
     service, _ = make_service()
     data = {
-        'url': '/path',
-        'isbn': '0',
-        'autor': 'n\xc3\xa3o especificado',
-        'serie': '',
-        'volume': '0',
-        'mes': '',
-        'img_url': 'https://img',
-        'generos': []
+        "url": "/path",
+        "isbn": "0",
+        "autor": "n\xc3\xa3o especificado",
+        "serie": "",
+        "volume": "0",
+        "mes": "",
+        "img_url": "https://img",
+        "generos": [],
     }
     service._clean_book_json_data(data)
-    assert data['isbn'] is None
-    assert data['url'].startswith('https://')
+    assert data["isbn"] is None
+    assert data["url"].startswith("https://")
 
 
 def test_search_and_reviews_and_users():
     search_html = (
-        "<div class=\"box_lista_busca_vertical\">\n"
-        "<a class=\"capa-link-item\" title=\"B\" href=\"/book/10-b-ed20.html\"><img src=\"https://x\"></a>\n"
-        "<div class=\"contador\">1 encontrados</div>"
+        '<div class="box_lista_busca_vertical">\n'
+        '<a class="capa-link-item" title="B" href="/book/10-b-ed20.html"><img src="https://x"></a>\n'
+        '<div class="contador">1 encontrados</div>'
     )
     service, client = make_service(html=search_html)
-    results = service.search('q')
+    results = service.search("q")
     assert results.total == 1 and results.results[0].book_id == 10
 
     reviews_html = (
-        "<div id=\"pg-livro-menu-principal-container\"><a href=\"/book/10-b-ed20.html\"></a></div>"
+        '<div id="pg-livro-menu-principal-container"><a href="/book/10-b-ed20.html"></a></div>'
         "<div id=\"resenha1\"><a href='/usuario/5-user'></a>"
         "<a href='/livro/10-b-ed20.html'></a><star-rating rate=\"3\"/>"
-        "<div id=\"resenhac1\"><span>01/01/2020</span>Great</div></div>"
+        '<div id="resenhac1"><span>01/01/2020</span>Great</div></div>'
     )
     client.text = reviews_html
     revs = service.get_reviews(10)

--- a/tests/test_skoob_client.py
+++ b/tests/test_skoob_client.py
@@ -1,4 +1,3 @@
-
 from pyskoob import SkoobClient
 
 
@@ -8,7 +7,8 @@ def test_client_context_manager(monkeypatch):
     def fake_close(self):
         nonlocal closed
         closed = True
-    monkeypatch.setattr('httpx.Client.close', fake_close, raising=False)
+
+    monkeypatch.setattr("httpx.Client.close", fake_close, raising=False)
 
     with SkoobClient() as client:
         assert client.auth

--- a/tests/test_skoob_parser_utils.py
+++ b/tests/test_skoob_parser_utils.py
@@ -2,16 +2,16 @@ from pyskoob.utils import skoob_parser_utils as spu
 
 
 def test_get_book_id_from_url():
-    assert spu.get_book_id_from_url('https://www.skoob.com.br/123-title') == '123'
-    url = 'https://www.skoob.com.br/title-123ed456.html'
-    assert spu.get_book_id_from_url(url) == '123'
+    assert spu.get_book_id_from_url("https://www.skoob.com.br/123-title") == "123"
+    url = "https://www.skoob.com.br/title-123ed456.html"
+    assert spu.get_book_id_from_url(url) == "123"
 
 
 def test_get_book_edition_and_user_id():
-    url = 'https://www.skoob.com.br/title-123ed456.html'
-    assert spu.get_book_edition_id_from_url(url) == '456'
-    assert spu.get_user_id_from_url('https://www.skoob.com.br/usuario/55-name') == '55'
+    url = "https://www.skoob.com.br/title-123ed456.html"
+    assert spu.get_book_edition_id_from_url(url) == "456"
+    assert spu.get_user_id_from_url("https://www.skoob.com.br/usuario/55-name") == "55"
 
 
 def test_get_author_id_from_url():
-    assert spu.get_author_id_from_url('https://www.skoob.com.br/autor/77-john') == '77'
+    assert spu.get_author_id_from_url("https://www.skoob.com.br/autor/77-john") == "77"

--- a/tests/test_skoob_user_service.py
+++ b/tests/test_skoob_user_service.py
@@ -20,7 +20,7 @@ class DummyAuth:
 
 
 class DummyClient:
-    def __init__(self, text='', json_data=None):
+    def __init__(self, text="", json_data=None):
         self.text = text
         self.json_data = json_data or {}
         self.called = []
@@ -36,7 +36,7 @@ class DummyClient:
         return self.json_data
 
 
-def make_service(html='', json_data=None):
+def make_service(html="", json_data=None):
     client = DummyClient(text=html, json_data=json_data)
     auth = DummyAuth()
     return (
@@ -47,15 +47,15 @@ def make_service(html='', json_data=None):
 
 def test_get_read_stats_and_bookcase():
     json_data = {
-        'response': {
-            'ano': 2024,
-            'lido': 1,
-            'paginas_lidas': 10,
-            'paginas_total': 100,
-            'percentual_lido': 10,
-            'total': 2,
-            'velocidade_dia': 1,
-            'velocidade_ideal': 2,
+        "response": {
+            "ano": 2024,
+            "lido": 1,
+            "paginas_lidas": 10,
+            "paginas_total": 100,
+            "percentual_lido": 10,
+            "total": 2,
+            "velocidade_dia": 1,
+            "velocidade_ideal": 2,
         }
     }
     service, client = make_service(json_data=json_data)
@@ -63,20 +63,20 @@ def test_get_read_stats_and_bookcase():
     assert stats.year == 2024
 
     bookcase_json = {
-        'response': [
+        "response": [
             {
-                'edicao': {'livro_id': 1, 'id': 2},
-                'ranking': 3,
-                'favorito': True,
-                'desejado': False,
-                'troco': False,
-                'tenho': True,
-                'emprestei': False,
-                'meta': None,
-                'paginas_lidas': 0,
+                "edicao": {"livro_id": 1, "id": 2},
+                "ranking": 3,
+                "favorito": True,
+                "desejado": False,
+                "troco": False,
+                "tenho": True,
+                "emprestei": False,
+                "meta": None,
+                "paginas_lidas": 0,
             }
         ],
-        'paging': {'next_page': None},
+        "paging": {"next_page": None},
     }
     client.json_data = bookcase_json
     books = service.get_bookcase(5, BookcaseOption.READ)
@@ -84,12 +84,9 @@ def test_get_read_stats_and_bookcase():
 
 
 def test_search_and_relations_and_reviews():
-    html = (
-        '<div style="border: 1px solid #e4e4e4"><a href="/usuario/10-john">John</a></div>'
-        '<div class="contador">1 encontrados</div>'
-    )
+    html = '<div style="border: 1px solid #e4e4e4"><a href="/usuario/10-john">John</a></div><div class="contador">1 encontrados</div>'
     service, client = make_service(html=html)
-    res = service.search('john')
+    res = service.search("john")
     assert res.total == 1 and res.results[0].id == 10
 
     relations_html = '<div class="usuarios-mini-lista-txt"><a href="/usuario/20-doe"></a></div>'
@@ -108,7 +105,6 @@ def test_search_and_relations_and_reviews():
     assert rev.results[0].rating == 5
 
 
-
 @pytest.mark.parametrize(
     "gender,state,frag",
     [
@@ -118,10 +114,7 @@ def test_search_and_relations_and_reviews():
     ],
 )
 def test_search_filters(logged_auth: AuthService, dummy_client: DummyClient, gender, state, frag):
-    html = (
-        "<div style='border: 1px solid #e4e4e4'>"
-        "<a href='/usuario/1-a'>A</a></div><div class='contador'>1 encontrados</div>"
-    )
+    html = "<div style='border: 1px solid #e4e4e4'><a href='/usuario/1-a'>A</a></div><div class='contador'>1 encontrados</div>"
     dummy_client.text = html
     service = UserService(cast(SyncHTTPClient, dummy_client), logged_auth)
     res = service.search("a", gender=gender, state=state)
@@ -147,14 +140,8 @@ def test_get_by_id_not_found(dummy_client: DummyClient):
 
 def test_get_reviews_invalid_date(dummy_client: DummyClient):
     service = UserService(cast(SyncHTTPClient, dummy_client), cast(AuthService, DummyAuth()))
-    html = (
-        "<div id='resenha1'>"
-        "<a href='/livro/1ed2.html'></a>"
-        "<div id='resenhac1'><span>bad</span>Text</div>"
-        "<star-rating rate='2'/></div>"
-    )
+    html = "<div id='resenha1'><a href='/livro/1ed2.html'></a><div id='resenhac1'><span>bad</span>Text</div><star-rating rate='2'/></div>"
     dummy_client.text = html
     reviews = service.get_reviews(5)
     assert reviews.results[0].reviewed_at is None
     assert reviews.results[0].review_text == "Text"
-


### PR DESCRIPTION
## Summary
- introduce `HTTPClientError` and translate `httpx` failures within the HTTP client
- remove direct `httpx` usage from book and publisher services
- export the new exception and record the decoupled error handling in the changelog
- format codebase with `ruff` to satisfy style checks
- preserve `HTTPClientError` propagation in book services and handle HTTP failures in user search
- propagate `HTTPClientError` in publisher service to maintain error specificity

## Testing
- `ruff format --check .`
- `ruff check .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688d7ed141148329ba96d45d09b5b396