### PR TITLE
refactor: standardize logging with parameterized messages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,13 +11,17 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) 
 - Example script demonstrating AuthorService usage.
 - Documentation for pagination and asynchronous usage examples.
 - List of stable public API exports.
+- Security policy describing vulnerability reporting and secret management.
 ### Fixed
 - Avoided ``httpx`` deprecation warning when posting raw bytes or text.
+- Updated PyPI publish workflow to use the latest action release, resolving missing metadata errors.
 
 ### Changed
 - Removed the standalone lint workflow and moved Ruff earlier in the CI job.
 - Added a dedicated step to install Ruff before running linting.
 - Fixed installation command for Ruff to target the system environment.
+- Restricted the release workflow to run only after the Bump Version workflow succeeds on the `main` branch.
+- Standardized logging statements to use parameterized style instead of f-strings.
 
 ## [0.1.0] - 2025-07-30
 ### Added

--- a/pyskoob/auth.py
+++ b/pyskoob/auth.py
@@ -52,7 +52,7 @@ class AuthService(BaseSkoobService):
         self.client.cookies.update({"PHPSESSID": session_token})
         user = self.get_my_info()
         self._is_logged_in = True
-        logger.info(f"Successfully logged in as user: '{user.name}'")
+        logger.info("Successfully logged in as user: '%s'", user.name)
         return user
 
     def login(self, email: str, password: str) -> User:
@@ -95,7 +95,11 @@ class AuthService(BaseSkoobService):
         try:
             json_data = response.json()
         except ValueError as exc:
-            logger.error("Login response was not valid JSON")
+            logger.error(
+                "Login response was not valid JSON: %s",
+                exc,
+                exc_info=True,
+            )
             raise ConnectionError("Invalid response format") from exc
         if not json_data.get("success", False):
             logger.error(
@@ -152,7 +156,7 @@ class AuthService(BaseSkoobService):
             self.base_url + user_data["url"]
         )  # patch field for alias
         user = User.model_validate(user_data)
-        logger.info(f"Successfully retrieved user: '{user.name}'")
+        logger.info("Successfully retrieved user: '%s'", user.name)
         return user
 
     def validate_login(self) -> None:

--- a/pyskoob/users.py
+++ b/pyskoob/users.py
@@ -90,14 +90,14 @@ class UserService(BaseSkoobService):
         'Example'
         """
         self._validate_login()
-        logger.info(f"Getting user by id: {user_id}")
+        logger.info("Getting user by id: %s", user_id)
         url = f"{self.base_url}/v1/user/{user_id}/stats:true"
         response = self.client.get(url)
         response.raise_for_status()
 
         json_data = response.json()
         if not json_data.get("success"):
-            logger.warning(f"User with ID {user_id} not found.")
+            logger.warning("User with ID %s not found.", user_id)
             raise FileNotFoundError(f"User with ID {user_id} not found.")
 
         user_data = json_data["response"]
@@ -105,7 +105,7 @@ class UserService(BaseSkoobService):
             self.base_url + user_data["url"]
         )  # patch field for alias
         user = User.model_validate(user_data)
-        logger.info(f"Successfully retrieved user: '{user.name}'")
+        logger.info("Successfully retrieved user: '%s'", user.name)
         return user
 
     def get_relations(
@@ -141,7 +141,10 @@ class UserService(BaseSkoobService):
         self._validate_login()
         url = f"{self.base_url}/{relation.value}/listar/{user_id}/page:{page}/limit:100"
         logger.info(
-            f"Getting '{relation.value}' for user_id: {user_id}, page: {page}"
+            "Getting '%s' for user_id: %s, page: %s",
+            relation.value,
+            user_id,
+            page,
         )
         response = self.client.get(url)
         response.raise_for_status()
@@ -158,10 +161,14 @@ class UserService(BaseSkoobService):
             ]
             next_page_link = safe_find(soup, "div", {"class": "proximo"})
         except (AttributeError, ValueError, IndexError) as e:
-            logger.error(f"Failed to parse user relations: {e}")
+            logger.error(
+                "Failed to parse user relations: %s",
+                e,
+                exc_info=True,
+            )
             raise ParsingError("Failed to parse user relations.") from e
 
-        logger.info(f"Found {len(users_id)} users on page {page}.")
+        logger.info("Found %s users on page %s.", len(users_id), page)
         return Pagination(
             results=users_id,
             limit=100,
@@ -199,7 +206,7 @@ class UserService(BaseSkoobService):
         url = (
             f"{self.base_url}/estante/resenhas/{user_id}/mpage:{page}/limit:50"
         )
-        logger.info(f"Getting reviews for user_id: {user_id}, page: {page}")
+        logger.info("Getting reviews for user_id: %s, page: %s", user_id, page)
         response = self.client.get(url)
         response.raise_for_status()
 
@@ -254,10 +261,14 @@ class UserService(BaseSkoobService):
                 )
             next_page_link = safe_find(soup, "a", {"string": " Próxima"})
         except (AttributeError, ValueError, IndexError) as e:
-            logger.error(f"Failed to parse user reviews: {e}")
+            logger.error(
+                "Failed to parse user reviews: %s",
+                e,
+                exc_info=True,
+            )
             raise ParsingError("Failed to parse user reviews.") from e
 
-        logger.info(f"Found {len(user_reviews)} reviews on page {page}.")
+        logger.info("Found %s reviews on page %s.", len(user_reviews), page)
         return Pagination(
             results=user_reviews,
             limit=50,
@@ -283,7 +294,7 @@ class UserService(BaseSkoobService):
             The user's reading statistics.
         """
         self._validate_login()
-        logger.info(f"Getting read stats for user_id: {user_id}")
+        logger.info("Getting read stats for user_id: %s", user_id)
         url = f"{self.base_url}/v1/meta_stats/{user_id}"
 
         response = self.client.get(url)
@@ -303,7 +314,8 @@ class UserService(BaseSkoobService):
             ideal_reading_speed=json_data.get("velocidade_ideal"),
         )
         logger.info(
-            f"Successfully retrieved read stats for user_id: {user_id}"
+            "Successfully retrieved read stats for user_id: %s",
+            user_id,
         )
         return stats
 
@@ -330,7 +342,10 @@ class UserService(BaseSkoobService):
         self._validate_login()
         url = f"{self.base_url}/v1/bookcase/books/{user_id}/shelf_id:{bookcase_option.value}/page:{page}/limit:100"
         logger.info(
-            f"Getting bookcase for user_id: {user_id}, option: '{bookcase_option.name}', page: {page}"
+            "Getting bookcase for user_id: %s, option: '%s', page: %s",
+            user_id,
+            bookcase_option.name,
+            page,
         )
         response = self.client.get(url)
         response.raise_for_status()
@@ -356,7 +371,7 @@ class UserService(BaseSkoobService):
                 )
             )
 
-        logger.info(f"Found {len(results)} books on page {page}.")
+        logger.info("Found %s books on page %s.", len(results), page)
         return Pagination(
             limit=100,
             results=results,


### PR DESCRIPTION
## Summary
- replace f-string logging with parameterized style across services
- document logging style change in changelog
- log exceptions with full context for failed auth and user lookups

## Testing
- `ruff check .`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_688d7edee4d48329854835dbbc16ebef