### PR TITLE
chore: run CI only on pull requests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,9 +1,9 @@
 name: Continuous Integration
 
-# Run lint and tests on each push and pull request
+# Run lint and tests on pull requests
 on:
-  push:
   pull_request:
+    branches: [main]
 
 permissions:
   contents: read


### PR DESCRIPTION
## Summary
- remove push trigger from CI workflow to avoid duplicate runs

## Testing
- `pre-commit run --all-files`
- `ruff format --check .`
- `ruff check .`
- `pytest -vv`


------
https://chatgpt.com/codex/tasks/task_e_688f77a97a048329bf80ecc5484d52f2