### PR TITLE
refactor: use robust URL parsing for ID extraction

### DIFF
--- a/pyskoob/utils/skoob_parser_utils.py
+++ b/pyskoob/utils/skoob_parser_utils.py
@@ -4,10 +4,14 @@ These functions extract numeric identifiers for books, editions, users, and
 authors from their respective Skoob links.
 """
 
+from __future__ import annotations
+
+import re
+from urllib.parse import urlparse
+
 
 def get_book_id_from_url(url: str) -> str:
-    """
-    Extracts the book ID from a Skoob book URL.
+    """Extract the book ID from a Skoob book URL.
 
     Parameters
     ----------
@@ -19,22 +23,25 @@ def get_book_id_from_url(url: str) -> str:
     str
         The book ID.
 
+    Raises
+    ------
+    ValueError
+        If the URL does not contain a book ID.
+
     Examples
     --------
     >>> get_book_id_from_url('https://www.skoob.com.br/livro/1-ed1.html')
     '1'
     """
-    filename = url.split("/")[-1]
-    parts = filename.split("-")
-    if parts[0].isdigit():
-        return parts[0]
-    else:
-        return parts[-1].split("ed")[0].strip()
+    path = urlparse(url).path
+    match = re.search(r"(\d+)", path)
+    if not match:
+        raise ValueError(f"Book ID not found in URL: {url}")
+    return match.group(1)
 
 
 def get_book_edition_id_from_url(url: str) -> str:
-    """
-    Extracts the book edition ID from a Skoob book URL.
+    """Extract the book edition ID from a Skoob book URL.
 
     Parameters
     ----------
@@ -46,17 +53,25 @@ def get_book_edition_id_from_url(url: str) -> str:
     str
         The book edition ID.
 
+    Raises
+    ------
+    ValueError
+        If the URL does not contain an edition ID.
+
     Examples
     --------
     >>> get_book_edition_id_from_url('https://www.skoob.com.br/livro/1-ed10.html')
     '10'
     """
-    return url.split("ed")[-1].replace(".html", "")
+    path = urlparse(url).path
+    match = re.search(r"ed(\d+)", path)
+    if not match:
+        raise ValueError(f"Book edition ID not found in URL: {url}")
+    return match.group(1)
 
 
 def get_user_id_from_url(url: str) -> str:
-    """
-    Extracts the user ID from a Skoob user URL.
+    """Extract the user ID from a Skoob user URL.
 
     Parameters
     ----------
@@ -68,12 +83,21 @@ def get_user_id_from_url(url: str) -> str:
     str
         The user ID.
 
+    Raises
+    ------
+    ValueError
+        If the URL does not contain a user ID.
+
     Examples
     --------
     >>> get_user_id_from_url('https://www.skoob.com.br/usuario/5-name')
     '5'
     """
-    return url.split("/")[-1].split("-")[0]
+    path = urlparse(url).path
+    match = re.search(r"/usuario/(\d+)", path)
+    if not match:
+        raise ValueError(f"User ID not found in URL: {url}")
+    return match.group(1)
 
 
 def get_author_id_from_url(url: str) -> str:
@@ -89,9 +113,18 @@ def get_author_id_from_url(url: str) -> str:
     str
         The author ID.
 
+    Raises
+    ------
+    ValueError
+        If the URL does not contain an author ID.
+
     Examples
     --------
     >>> get_author_id_from_url('https://www.skoob.com.br/autor/50-name')
     '50'
     """
-    return url.split("/")[-1].split("-")[0]
+    path = urlparse(url).path
+    match = re.search(r"/autor/(\d+)", path)
+    if not match:
+        raise ValueError(f"Author ID not found in URL: {url}")
+    return match.group(1)

--- a/tests/test_skoob_parser_utils.py
+++ b/tests/test_skoob_parser_utils.py
@@ -5,13 +5,24 @@ def test_get_book_id_from_url():
     assert spu.get_book_id_from_url("https://www.skoob.com.br/123-title") == "123"
     url = "https://www.skoob.com.br/title-123ed456.html"
     assert spu.get_book_id_from_url(url) == "123"
+    url_with_query = "https://www.skoob.com.br/livro/123-ed10.html?ref=foo"
+    assert spu.get_book_id_from_url(url_with_query) == "123"
 
 
 def test_get_book_edition_and_user_id():
     url = "https://www.skoob.com.br/title-123ed456.html"
     assert spu.get_book_edition_id_from_url(url) == "456"
-    assert spu.get_user_id_from_url("https://www.skoob.com.br/usuario/55-name") == "55"
+    url_with_query = "https://www.skoob.com.br/livro/123-ed456.html?foo=bar"
+    assert spu.get_book_edition_id_from_url(url_with_query) == "456"
+    assert (
+        spu.get_user_id_from_url("https://www.skoob.com.br/usuario/55-name/?x=y")
+        == "55"
+    )
 
 
 def test_get_author_id_from_url():
     assert spu.get_author_id_from_url("https://www.skoob.com.br/autor/77-john") == "77"
+    assert (
+        spu.get_author_id_from_url("https://www.skoob.com.br/autor/77-john/?ref=bar")
+        == "77"
+    )

--- a/tests/test_skoob_parser_utils.py
+++ b/tests/test_skoob_parser_utils.py
@@ -14,15 +14,9 @@ def test_get_book_edition_and_user_id():
     assert spu.get_book_edition_id_from_url(url) == "456"
     url_with_query = "https://www.skoob.com.br/livro/123-ed456.html?foo=bar"
     assert spu.get_book_edition_id_from_url(url_with_query) == "456"
-    assert (
-        spu.get_user_id_from_url("https://www.skoob.com.br/usuario/55-name/?x=y")
-        == "55"
-    )
+    assert spu.get_user_id_from_url("https://www.skoob.com.br/usuario/55-name/?x=y") == "55"
 
 
 def test_get_author_id_from_url():
     assert spu.get_author_id_from_url("https://www.skoob.com.br/autor/77-john") == "77"
-    assert (
-        spu.get_author_id_from_url("https://www.skoob.com.br/autor/77-john/?ref=bar")
-        == "77"
-    )
+    assert spu.get_author_id_from_url("https://www.skoob.com.br/autor/77-john/?ref=bar") == "77"


### PR DESCRIPTION
## Summary
- improve URL parser utilities using `urllib.parse` and regex with clear errors
- extend parser tests for URLs with query strings and trailing slashes

## Testing
- `ruff check pyskoob/utils/skoob_parser_utils.py tests/test_skoob_parser_utils.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_688ec87b8f8083298946b9ef8358a9fb