### PR TITLE
test: subclass FalsySoup for type safety

### DIFF
--- a/tests/test_bs4_utils.py
+++ b/tests/test_bs4_utils.py
@@ -25,20 +25,14 @@ def test_get_tag_text_and_attr():
     assert bs4_utils.get_tag_attr(None, "href", "default") == "default"
 
 
-class FalsySoup:
-    """A BeautifulSoup wrapper that evaluates to False."""
+class FalsySoup(BeautifulSoup):
+    """A ``BeautifulSoup`` subclass that evaluates to ``False``."""
 
     def __init__(self, html: str) -> None:
-        self._soup = BeautifulSoup(html, "html.parser")
+        super().__init__(html, "html.parser")
 
     def __bool__(self) -> bool:  # pragma: no cover - behavior is deterministic
         return False
-
-    def find(self, name, attrs):  # type: ignore[no-untyped-def]
-        return self._soup.find(name, attrs)
-
-    def find_all(self, name, attrs):  # type: ignore[no-untyped-def]
-        return self._soup.find_all(name, attrs)
 
 
 def test_safe_find_handles_falsy_soup() -> None:


### PR DESCRIPTION
## Summary
- make FalsySoup inherit from BeautifulSoup while evaluating to False

## Testing
- `ruff format .`
- `ruff format --check .`
- `ruff check .`
- `pre-commit run --all-files`
- `pytest -vv`


------
https://chatgpt.com/codex/tasks/task_e_688fd4f383388329a151b8a091a28fde