### PR TITLE
docs: update README badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,6 @@
 # PySkoob
-[![Latest Tag](https://img.shields.io/github/v/tag/victor-soeiro/pyskoob?sort=semver&style=flat-square)](https://github.com/victor-soeiro/pyskoob/releases)
 [![PyPI Version](https://img.shields.io/pypi/v/pyskoob?style=flat-square&logo=pypi)](https://pypi.org/project/pyskoob/)
-[![Python Versions](https://img.shields.io/pypi/pyversions/pyskoob?style=flat-square&logo=python)](https://pypi.org/project/pyskoob/)
-[![PyPI Downloads](https://img.shields.io/pypi/dm/pyskoob?style=flat-square)](https://pypi.org/project/pyskoob/)
-[![CI](https://img.shields.io/github/actions/workflow/status/victor-soeiro/pyskoob/ci.yml?style=flat-square)](https://github.com/victor-soeiro/pyskoob/actions/workflows/ci.yml)
+![Python 3.11+](https://img.shields.io/badge/python-3.11%2B-blue?style=flat-square&logo=python)
 [![Coverage](https://raw.githubusercontent.com/victor-soeiro/pyskoob/main/coverage.svg)](https://github.com/victor-soeiro/pyskoob/actions/workflows/ci.yml)
 [![Docs](https://img.shields.io/badge/docs-latest-blue?style=flat-square)](https://victor-soeiro.github.io/pyskoob/)
 [![License](https://img.shields.io/github/license/victor-soeiro/pyskoob?style=flat-square)](LICENSE)


### PR DESCRIPTION
## Summary
- streamline README badges by dropping tag, download, and build status icons
- add explicit Python 3.11+ support badge

## Testing
- `pre-commit run --all-files`
- `ruff format --check .`
- `ruff check .`
- `pytest -vv`


------
https://chatgpt.com/codex/tasks/task_e_68900c01bf7c8329bd001e98923cbb40

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated README badges to display support for Python 3.11 and above, removing outdated badges for releases, Python versions, downloads, and CI status. Remaining badges for PyPI version, coverage, documentation, and license are unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->