### PR TITLE
fix: stabilize release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,7 +34,7 @@ jobs:
 
       - name: Install dependencies
         run: |
-          python -m pip install bump-my-version==1.2.1 build mkdocs
+          python -m pip install bump-my-version==1.2.1 build mkdocs mkdocs-material 'mkdocstrings[python]'
           sudo apt-get update && sudo apt-get install -y jq
 
       - name: Configure git
@@ -51,9 +51,14 @@ jobs:
 
       - name: Tag and push
         run: |
-          git tag "v${{ steps.bump.outputs.version }}"
           git push origin HEAD
-          git push origin "v${{ steps.bump.outputs.version }}"
+          git fetch --tags
+          if git rev-parse "v${{ steps.bump.outputs.version }}" >/dev/null 2>&1; then
+            echo "Tag v${{ steps.bump.outputs.version }} already exists, skipping creation"
+          else
+            git tag "v${{ steps.bump.outputs.version }}"
+            git push origin "v${{ steps.bump.outputs.version }}"
+          fi
 
       - name: Build package
         run: python -m build

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) 
 ### Fixed
 - Avoided ``httpx`` deprecation warning when posting raw bytes or text.
 - Updated PyPI publish workflow to use the latest action release, resolving missing metadata errors.
+- Installed `mkdocs-material` in the release workflow to resolve missing theme errors.
+- Prevented release failures by skipping tag creation when the version tag already exists.
 
 ### Changed
 - Removed the standalone lint workflow and moved Ruff earlier in the CI job.


### PR DESCRIPTION
## Summary
- install mkdocs-material and mkdocstrings for release workflow
- skip tag creation if tag already exists to avoid release failure
- document release workflow fixes in changelog

## Testing
- `pre-commit run --all-files`
- `pytest -vv`
- `mkdocs build --strict`


------
https://chatgpt.com/codex/tasks/task_e_6890156bb5488329a88ce406672de246