### PR TITLE
ci: add documentation deployment workflow

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,47 @@
+name: Deploy Documentation
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: "pages"
+  cancel-in-progress: true
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+      - name: Set up uv
+        uses: astral-sh/setup-uv@v6
+      - name: Install documentation dependencies
+        run: uv pip install --system -e .[docs]
+      - name: Build documentation
+        run: mkdocs build
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: site
+
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) 
 - Introduced `AuthenticatedService` base class to centralize login validation for services requiring authentication.
 - Pre-commit configuration for Ruff, formatting and tests.
 - Security policy describing vulnerability reporting and secret management.
+- Automated GitHub Pages workflow to build and deploy documentation.
 ### Fixed
 - Avoided ``httpx`` deprecation warning when posting raw bytes or text.
 - Updated PyPI publish workflow to use the latest action release, resolving missing metadata errors.


### PR DESCRIPTION
## Summary
- build and deploy MkDocs site to GitHub Pages on pushes to `main`

## Testing
- `ruff format --check .`
- `ruff check .`
- `pytest -vv`
- `pre-commit run --all-files`


------
https://chatgpt.com/codex/tasks/task_e_68909e22f1e08329b7446a7cb5e584ff