### PR TITLE
feat: add author profile and books scraping

### DIFF
--- a/pyskoob/authors.py
+++ b/pyskoob/authors.py
@@ -4,10 +4,19 @@ import re
 from bs4 import Tag
 
 from pyskoob.internal.base import BaseSkoobService
-from pyskoob.models.author import AuthorSearchResult
+from pyskoob.models.author import AuthorBook, AuthorProfile, AuthorSearchResult, AuthorStats, AuthorVideo
+from pyskoob.models.book import BookSearchResult
 from pyskoob.models.pagination import Pagination
-from pyskoob.utils.bs4_utils import get_tag_attr, get_tag_text, safe_find, safe_find_all
-from pyskoob.utils.skoob_parser_utils import get_author_id_from_url
+from pyskoob.utils.bs4_utils import (
+    get_tag_attr,
+    get_tag_text,
+    safe_find,
+    safe_find_all,
+)
+from pyskoob.utils.skoob_parser_utils import (
+    get_author_id_from_url,
+    get_book_id_from_url,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -118,3 +127,242 @@ class AuthorService(BaseSkoobService):
         contador = safe_find(soup, "div", {"class": "contador"})
         match = re.search(r"(\d+)", get_tag_text(contador))
         return int(match.group(1)) if match else 0
+
+    # ------------------------------------------------------------------
+    # Author profile
+    def get_by_id(self, author_id: int) -> AuthorProfile:
+        """Retrieve detailed information about an author.
+
+        Parameters
+        ----------
+        author_id : int
+            Identifier of the author on Skoob.
+
+        Returns
+        -------
+        AuthorProfile
+            Structured profile data for the requested author.
+
+        Examples
+        --------
+        >>> service.get_by_id(1).name
+        'Some Author'
+        """
+
+        url = f"{self.base_url}/autor/{author_id}"
+        logger.info("Fetching author profile: %s", url)
+        response = self.client.get(url)
+        response.raise_for_status()
+        soup = self.parse_html(response.text)
+        return self._parse_author_profile(soup)
+
+    def _parse_author_profile(self, soup: Tag) -> AuthorProfile:  # noqa: C901
+        name = get_tag_text(safe_find(soup, "h1", {"class": "given-name"}))
+        photo_url = get_tag_attr(safe_find(soup, "img", {"class": "img-rounded"}), "src")
+
+        links: dict[str, str] = {}
+        for a in safe_find_all(safe_find(soup, "div", {"id": "autor-icones"}), "a"):
+            span = safe_find(a, "span")
+            cls = get_tag_attr(span, "class", "")
+            if isinstance(cls, list):
+                cls = cls[0]
+            key = str(cls).replace("icon-", "")
+            href = get_tag_attr(a, "href")
+            if href:
+                links[key] = href
+
+        box_generos = safe_find(soup, "div", {"id": "box-generos"})
+        birth_date = None
+        location = None
+        if box_generos:
+            birth_b = box_generos.find("b", string=lambda s: s and "Nascimento" in s)
+            if birth_b and birth_b.next_sibling:
+                birth_date = str(birth_b.next_sibling).strip(" |")
+            loc_b = box_generos.find("b", string=lambda s: s and "Local" in s)
+            if loc_b and loc_b.next_sibling:
+                loc_tag = loc_b.next_sibling
+                if isinstance(loc_tag, Tag):
+                    location = get_tag_text(loc_tag)
+                else:  # pragma: no cover - defensive
+                    location = str(loc_tag).strip()
+
+        description = get_tag_text(safe_find(soup, "div", {"id": "livro-perfil-sinopse-txt"}))
+        tags = [get_tag_text(t) for t in safe_find_all(soup, "div", {"class": "genero-item"})]
+
+        stats_div = safe_find(soup, "div", {"id": "livro-perfil-status02"})
+        followers = readers = ratings = None
+        average_rating = None
+        if stats_div:
+            rating_span = safe_find(stats_div, "span", {"class": "rating"})
+            rating_text = get_tag_text(rating_span).replace(",", ".")
+            average_rating = float(rating_text) if rating_text else None
+            aval_span = stats_div.find("span", string=lambda t: t and "avalia" in t.lower())
+            if aval_span:
+                aval_match = re.search(r"(\d+)", get_tag_text(aval_span).replace(".", ""))
+                ratings = int(aval_match.group(1)) if aval_match else None
+            for bar in safe_find_all(stats_div, "div", {"class": "bar"}):
+                label = get_tag_text(safe_find(bar, "a")).lower()
+                value_text = get_tag_text(safe_find(bar, "b")).replace(".", "")
+                value = int(value_text) if value_text.isdigit() else None
+                if "livros" in label:
+                    # count ignored but kept for completeness
+                    pass
+                elif "leitores" in label:
+                    readers = value
+                elif "seguidores" in label:
+                    followers = value
+
+        star_ratings: dict[str, float] = {}
+        for img in safe_find_all(soup, "img", {"src": re.compile("estrela")}):
+            alt = get_tag_attr(img, "alt")
+            percent_tag = img.find_next("div", string=re.compile("%"))
+            if alt and percent_tag:
+                star_ratings[alt] = float(get_tag_text(percent_tag).replace("%", ""))
+
+        male = female = None
+        male_icon = safe_find(soup, "i", {"class": re.compile("icon-male")})
+        if male_icon:
+            male_text = get_tag_text(male_icon.find_next("span")).replace("%", "")
+            male = float(male_text) if male_text else None
+        female_icon = safe_find(soup, "i", {"class": re.compile("icon-female")})
+        if female_icon:
+            female_text = get_tag_text(female_icon.find_next("span")).replace("%", "")
+            female = float(female_text) if female_text else None
+        gender: dict[str, float] = {}
+        if male is not None:
+            gender["male"] = male
+        if female is not None:
+            gender["female"] = female
+
+        books = [
+            AuthorBook(
+                url=f"{self.base_url}{get_tag_attr(a, 'href')}",
+                title=get_tag_attr(a, "title"),
+                img_url=get_tag_attr(safe_find(div, "img"), "src"),
+            )
+            for div in safe_find_all(soup, "div", {"class": "clivro livro-capa-mini"})
+            if (a := safe_find(div, "a"))
+        ]
+
+        videos = [
+            AuthorVideo(
+                url=f"{self.base_url}{get_tag_attr(a, 'href')}",
+                thumbnail_url=get_tag_attr(safe_find(a, "img"), "src"),
+                title=get_tag_attr(safe_find(a, "img"), "alt") or get_tag_text(a),
+            )
+            for a in [safe_find(div, "a") for div in safe_find_all(soup, "div", {"class": "livro-perfil-videos-cont"})]
+            if a
+        ]
+
+        created_at = created_by = edited_at = edited_by = approved_at = approved_by = None
+        info_div = safe_find(soup, "div", {"id": "box-info-cad"})
+        if info_div:
+            for box in safe_find_all(info_div, "div", {"class": "box-info-cad-user"}):
+                date_div = safe_find(box, "div", {"class": "box-info-cad-date"})
+                user_link = safe_find(date_div, "a")
+                user_name = get_tag_text(user_link)
+                text = get_tag_text(date_div)
+                if "cadastrou" in text:
+                    created_by = user_name
+                    created_at = text.split("cadastrou em:")[-1].strip()
+                elif "editou" in text:
+                    edited_by = user_name
+                    edited_at = text.split("editou em:")[-1].strip()
+                elif "aprovou" in text:
+                    approved_by = user_name
+                    approved_at = text.split("aprovou em:")[-1].strip()
+
+        stats = AuthorStats(
+            followers=followers,
+            readers=readers,
+            ratings=ratings,
+            average_rating=average_rating,
+            star_ratings=star_ratings,
+        )
+
+        return AuthorProfile(
+            name=name,
+            photo_url=photo_url,
+            links=links,
+            description=description,
+            tags=tags,
+            birth_date=birth_date,
+            location=location,
+            gender_percentages=gender,
+            books=books,
+            videos=videos,
+            stats=stats,
+            created_at=created_at,
+            created_by=created_by,
+            edited_at=edited_at,
+            edited_by=edited_by,
+            approved_at=approved_at,
+            approved_by=approved_by,
+        )
+
+    # ------------------------------------------------------------------
+    # Author books
+    def get_books(self, author_id: int, page: int = 1) -> Pagination[BookSearchResult]:
+        """Retrieve books written by the author.
+
+        Parameters
+        ----------
+        author_id : int
+            The author identifier.
+        page : int, optional
+            Pagination page, by default ``1``.
+
+        Returns
+        -------
+        Pagination[BookSearchResult]
+            Paginated list of books authored by the given ID.
+
+        Examples
+        --------
+        >>> service.get_books(1).results[0].title
+        'Book'
+        """
+
+        url = f"{self.base_url}/autor/livros/{author_id}/page:{page}"
+        logger.info("Fetching books for author %s page %s", author_id, page)
+        response = self.client.get(url)
+        response.raise_for_status()
+        soup = self.parse_html(response.text)
+
+        books = [self._parse_book_div(div) for div in safe_find_all(soup, "div", {"class": "clivro livro-capa-mini"})]
+        books = [b for b in books if b]
+
+        total_span = safe_find(soup, "span", {"class": "badge badge-ativa"})
+        total_text = get_tag_text(total_span).replace(".", "")
+        total = int(total_text) if total_text.isdigit() else len(books)
+
+        has_next = bool(safe_find(soup, "div", {"class": "proximo"}))
+
+        return Pagination(
+            results=books,
+            total=total,
+            page=page,
+            limit=len(books),
+            has_next_page=has_next,
+        )
+
+    def _parse_book_div(self, div: Tag) -> BookSearchResult | None:
+        anchor = safe_find(div, "a")
+        if not anchor:
+            return None
+        href = get_tag_attr(anchor, "href")
+        img = safe_find(anchor, "img")
+        title = get_tag_attr(anchor, "title") or get_tag_text(anchor)
+        edition_id_text = get_tag_attr(div, "id")
+        try:
+            edition_id = int(edition_id_text) if edition_id_text else int(get_book_id_from_url(href))
+            book_id = int(get_book_id_from_url(href)) if href else 0
+        except ValueError:  # pragma: no cover - defensive
+            return None
+        return BookSearchResult(
+            edition_id=edition_id,
+            book_id=book_id,
+            title=title,
+            url=f"{self.base_url}{href}",
+            cover_url=get_tag_attr(img, "src"),
+        )

--- a/tests/test_skoob_author_service.py
+++ b/tests/test_skoob_author_service.py
@@ -28,3 +28,69 @@ def test_parse_search_result():
     assert author.nickname == "nick"
     assert author.url.endswith("/autor/1-john")
     assert author.img_url == "img.jpg"
+
+
+def test_get_by_id_parses_profile():
+    html = (
+        "<div style='float:left;'><img class='img-rounded' src='p.jpg'></div>"
+        "<div id='autor-icones'><a href='http://site'><span class='icon-earth'></span></a></div>"
+        "<div id='box-descricao'><div id='box-nome'><h1 class='given-name'>A</h1></div>"
+        "<div id='livro-perfil-status02'><div class='span3'><div class='bg_green'><span class='rating'>4,8</span></div>"
+        "<div><span>info</span><span>100 avalia\xe7\xf5es</span></div></div>"
+        "<div class='bar'><a>LIVROS</a><b><a class='text_blue'>10</a></b></div>"
+        "<div class='bar'><a>LEITORES</a><b><a class='text_blue'>20</a></b></div>"
+        "<div class='bar'><a>SEGUIDORES</a><b><a class='text_blue'>30</a></b></div></div>"
+        "<div id='box-generos'><b>Nascimento: </b>01/01/2000 | "
+        "<b>Local: </b><span class='adr'>Brasil<span class='locality'> - SP - "
+        "Sao Paulo</span></span></div>"
+        "<div id='livro-perfil-sinopse-txt'>Desc</div>"
+        "<div class='genero-box'><div class='genero-item'>Fantasia</div></div></div>"
+        "<div class='span4' style='width:200px'><div><img src='5_estrela.gif' alt='5'/><div></div><div>80%</div></div>"
+        "<div><img src='4_estrela.gif' alt='4'/><div></div><div>20%</div></div></div>"
+        "<div class='span3' style='width:80px'><div class='row-fluid'><i class='icon-male'></i><span>60%</span></div>"
+        "<div class='row-fluid'><i class='icon-female'></i><span>40%</span></div></div>"
+        "<div class='perfil-box'><ul class='ul-lancamentos'><div class='clivro livro-capa-mini' id='10'>"
+        "<a href='/b1-ed10.html' title='B1'><img src='c1.jpg'></a></div></ul></div>"
+        "<div id='livro-perfil-videos'><div class='livro-perfil-videos-cont'>"
+        "<a href='/v1'><img src='v1.jpg' alt='V1'></a><a>V1</a></div></div>"
+        "<div id='box-info-cad'><div class='box-info-cad-user'><div class='box-info-cad-date'>"
+        "<a href='/usuario/1-a'>A1</a><br/>cadastrou em: <br>01/01/2020</div></div>"
+        "<div class='box-info-cad-user'><div class='box-info-cad-date'>"
+        "<a href='/usuario/2-b'>B1</a><br/>editou em: <br>02/02/2020</div></div>"
+        "<div class='box-info-cad-user'><div class='box-info-cad-date'>"
+        "<a href='/usuario/3-c'>C1</a><br/>aprovou em: <br>03/03/2020</div></div></div>"
+    )
+    service, _ = make_service(html)
+    profile = service.get_by_id(1)
+    assert profile.name == "A"
+    assert profile.photo_url == "p.jpg"
+    assert profile.links == {"earth": "http://site"}
+    assert profile.stats.followers == 30
+    assert profile.stats.readers == 20
+    assert profile.stats.ratings == 100
+    assert profile.stats.average_rating == 4.8
+    assert profile.stats.star_ratings["5"] == 80.0
+    assert profile.gender_percentages == {"male": 60.0, "female": 40.0}
+    assert profile.birth_date == "01/01/2000"
+    assert profile.location.startswith("Brasil")
+    assert profile.tags == ["Fantasia"]
+    assert profile.books[0].title == "B1"
+    assert profile.videos[0].title == "V1"
+    assert profile.created_by == "A1"
+    assert profile.edited_by == "B1"
+    assert profile.approved_by == "C1"
+
+
+def test_get_books_pagination():
+    html = (
+        "<div class='clivro livro-capa-mini' id='10'><a href='/b1-ed10.html' title='B1'><img src='i1.jpg'></a></div>"
+        "<span class='badge badge-ativa'>2</span><div class='proximo'></div>"
+    )
+    service, _ = make_service(html)
+    res = service.get_books(1)
+    book = res.results[0]
+    assert book.title == "B1"
+    assert book.edition_id == 10
+    assert book.book_id == 1
+    assert res.total == 2
+    assert res.has_next_page is True


### PR DESCRIPTION
## Summary
- add service to parse author profile information including stats and metadata
- add pagination service to list author books
- cover new services with unit tests

## Testing
- `pre-commit run --files pyskoob/authors.py tests/test_skoob_author_service.py`
- `pytest -vv`


------
https://chatgpt.com/codex/tasks/task_e_6890a04118f4832989833b7dd9d1e8ec