### PR TITLE
chore: synchronize version with PyPI 0.1.20

### DIFF
--- a/.bumpversion.toml
+++ b/.bumpversion.toml
@@ -1,5 +1,5 @@
 [tool.bumpversion]
-current_version = "0.1.19"
+current_version = "0.1.20"
 parse = "(?P<major>\\d+)\\.(?P<minor>\\d+)\\.(?P<patch>\\d+)"
 serialize = ["{major}.{minor}.{patch}"]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "pyskoob"
-version = "0.1.19"
+version = "0.1.20"
 description = "Python client for the Skoob website handling authentication and HTML parsing"
 readme = "README.md"
 keywords = ["skoob", "books", "client", "api", "scraping"]

--- a/pyskoob/__init__.py
+++ b/pyskoob/__init__.py
@@ -5,7 +5,7 @@ import from ``pyskoob``. Everything listed in ``__all__`` is considered stable
 and will not change without a deprecation period.
 """
 
-__version__ = "0.1.19"
+__version__ = "0.1.20"
 
 from . import models
 from .auth import AuthService


### PR DESCRIPTION
## Summary
- align project metadata with latest release 0.1.20

## Testing
- `ruff format .`
- `ruff format --check .`
- `ruff check .`
- `pre-commit run --all-files`
- `pytest -vv`


------
https://chatgpt.com/codex/tasks/task_e_6890b021062c83298770e660131a328b