### PR TITLE
docs: enhance MkDocs theme with Material features

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -5,7 +5,6 @@ theme:
   name: material
   features:
     - navigation.tabs
-    - navigation.top
     - search.highlight
     - content.code.copy
   palette:
@@ -34,7 +33,8 @@ nav:
   - Contributing: contributing.md
 markdown_extensions:
   - admonition
-  - codehilite
+  - pymdownx.highlight
+  - pymdownx.superfences
 plugins:
   - search
   - mkdocstrings:

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -3,9 +3,24 @@ repo_url: https://github.com/victor-soeiro/pyskoob
 docs_dir: docs
 theme:
   name: material
+  features:
+    - navigation.tabs
+    - navigation.top
+    - search.highlight
+    - content.code.copy
   palette:
-    primary: indigo
-    accent: indigo
+    - scheme: default
+      primary: indigo
+      accent: indigo
+      toggle:
+        icon: material/weather-night
+        name: Switch to dark mode
+    - scheme: slate
+      primary: indigo
+      accent: indigo
+      toggle:
+        icon: material/weather-sunny
+        name: Switch to light mode
 nav:
   - Home: index.md
   - Services:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -66,7 +66,7 @@ dev = [
 ]
 docs = [
     "mkdocs>=1.6.0",
-    "mkdocs-material>=9.6.0",
+    "mkdocs-material>=9.6.0,<10.0",
     "mkdocstrings[python]>=0.24.0",
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -66,7 +66,7 @@ dev = [
 ]
 docs = [
     "mkdocs>=1.6.0",
-    "mkdocs-material>=9.5.17",
+    "mkdocs-material>=9.6.0",
     "mkdocstrings[python]>=0.24.0",
 ]
 


### PR DESCRIPTION
## Summary
- enable Material theme options like navigation tabs, search highlighting, code copy button, and dark/light mode toggle
- require `mkdocs-material>=9.6.0` for documentation builds

## Testing
- `ruff format --check .`
- `ruff check .`
- `pre-commit run --all-files`
- `pytest -vv`
- `mkdocs build --strict`


------
https://chatgpt.com/codex/tasks/task_e_6890b5c713888329a040b1b471705d25

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enhanced documentation site with navigation tabs, search term highlighting, and code copy buttons.
  * Introduced light and dark color schemes with an easy toggle between modes.

* **Chores**
  * Updated documentation dependencies to require a newer version of the theme.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->