### PR TITLE
chore: regenerate uv.lock for reproducible dependencies

### DIFF
--- a/uv.lock
+++ b/uv.lock
@@ -2,7 +2,7 @@
 #    uv pip compile pyproject.toml --extra dev --extra docs -o uv.lock
 annotated-types==0.7.0
     # via pydantic
-anyio==4.9.0
+anyio==4.10.0
     # via httpx
 babel==2.17.0
     # via mkdocs-material
@@ -12,7 +12,7 @@ beautifulsoup4==4.13.4
     # via bs4
 bs4==0.0.2
     # via pyskoob (pyproject.toml)
-certifi==2025.7.14
+certifi==2025.8.3
     # via
     #   httpcore
     #   httpx
@@ -25,7 +25,7 @@ colorama==0.4.6
     # via
     #   griffe
     #   mkdocs-material
-coverage==7.10.1
+coverage==7.10.2
     # via pytest-cov
 ghp-import==2.1.0
     # via mkdocs


### PR DESCRIPTION
## Summary
- regenerate uv.lock with `uv pip compile` including dev and docs extras

## Testing
- `pre-commit run --all-files`
- `ruff format .`
- `ruff format --check .`
- `ruff check .`
- `pytest -vv`


------
https://chatgpt.com/codex/tasks/task_e_689164f7f8a48329ae17d28910e1032e