### PR TITLE
Add missing numpy-style docstrings

### DIFF
--- a/pyskoob/auth.py
+++ b/pyskoob/auth.py
@@ -8,6 +8,13 @@ logger = logging.getLogger(__name__)
 
 
 class AuthService(BaseSkoobService):
+    """Handle authentication with Skoob and track login state.
+
+    The service exposes login helpers and validates whether requests are
+    performed as an authenticated user. Other high-level services depend on
+    this class to ensure session-sensitive operations are authorized.
+    """
+
     def __init__(self, client: SyncHTTPClient):
         """Manage Skoob authentication and session validation.
 

--- a/pyskoob/internal/base.py
+++ b/pyskoob/internal/base.py
@@ -79,6 +79,16 @@ class BaseHttpService:
 
 
 class BaseSkoobService(BaseHttpService):
+    """Base class for services that talk to the Skoob website.
+
+    Notes
+    -----
+    This class preconfigures the base URL for Skoob endpoints and allows
+    subclasses to reuse a shared synchronous HTTP client. If no client is
+    provided, a :class:`~pyskoob.http.httpx.HttpxSyncClient` instance is
+    created automatically.
+    """
+
     def __init__(self, client: SyncHTTPClient | None):
         """
         Initializes the BaseSkoobService.

--- a/pyskoob/models/author.py
+++ b/pyskoob/models/author.py
@@ -2,6 +2,22 @@ from pydantic import BaseModel, ConfigDict, Field
 
 
 class AuthorSearchResult(BaseModel):
+    """Result entry returned by the author search endpoint.
+
+    Attributes
+    ----------
+    id : int
+        Unique identifier of the author.
+    name : str
+        Author's display name.
+    url : str
+        Full URL to the author's profile.
+    nickname : str
+        Nickname or alias for the author.
+    img_url : str
+        URL to the author's avatar image.
+    """
+
     id: int
     name: str
     url: str
@@ -12,6 +28,22 @@ class AuthorSearchResult(BaseModel):
 
 
 class AuthorStats(BaseModel):
+    """Aggregate statistics for an author profile.
+
+    Attributes
+    ----------
+    followers : int | None
+        Number of users following the author.
+    readers : int | None
+        Number of users who have read books by the author.
+    ratings : int | None
+        Total count of ratings received across all works.
+    average_rating : float | None
+        Average rating for the author's works.
+    star_ratings : dict[str, float]
+        Mapping of star values to their respective percentages.
+    """
+
     followers: int | None = None
     readers: int | None = None
     ratings: int | None = None
@@ -20,18 +52,82 @@ class AuthorStats(BaseModel):
 
 
 class AuthorBook(BaseModel):
+    """Lightweight representation of a book associated with an author.
+
+    Attributes
+    ----------
+    url : str | None
+        Link to the book's page on Skoob.
+    title : str | None
+        Title of the book.
+    img_url : str | None
+        URL to the book cover image.
+    """
+
     url: str | None = None
     title: str | None = None
     img_url: str | None = None
 
 
 class AuthorVideo(BaseModel):
+    """Video related to the author.
+
+    Attributes
+    ----------
+    url : str | None
+        Link to the video on Skoob or external platform.
+    thumbnail_url : str | None
+        URL of the video's thumbnail image.
+    title : str | None
+        Title of the video.
+    """
+
     url: str | None = None
     thumbnail_url: str | None = None
     title: str | None = None
 
 
 class AuthorProfile(BaseModel):
+    """Detailed profile information about an author.
+
+    Attributes
+    ----------
+    name : str
+        Author's full name.
+    photo_url : str | None
+        Link to the author's photo.
+    links : dict[str, str]
+        Mapping of social network names to URLs.
+    description : str
+        Free-form biography text.
+    tags : list[str]
+        List of genres or categories associated with the author.
+    birth_date : str | None
+        Author's birth date.
+    location : str | None
+        Location of birth or residence.
+    gender_percentages : dict[str, float]
+        Percentage distribution of readers by gender.
+    books : list[AuthorBook]
+        Books written by the author.
+    videos : list[AuthorVideo]
+        Related videos featuring the author.
+    stats : AuthorStats
+        Aggregated statistics.
+    created_at : str | None
+        Creation timestamp of the profile.
+    created_by : str | None
+        Username of the profile creator.
+    edited_at : str | None
+        Last edit timestamp.
+    edited_by : str | None
+        Username of the last editor.
+    approved_at : str | None
+        When the profile was approved.
+    approved_by : str | None
+        Username of the approver.
+    """
+
     name: str
     photo_url: str | None = None
     links: dict[str, str] = Field(default_factory=dict)

--- a/pyskoob/models/pagination.py
+++ b/pyskoob/models/pagination.py
@@ -6,6 +6,22 @@ T = TypeVar("T")
 
 
 class Pagination(BaseModel, Generic[T]):
+    """Generic container for paginated API responses.
+
+    Attributes
+    ----------
+    results : list[T]
+        Items returned for the current page.
+    total : int
+        Total number of items available.
+    page : int
+        Current page index starting at ``1``.
+    limit : int
+        Maximum number of items per page.
+    has_next_page : bool
+        ``True`` if more pages are available.
+    """
+
     results: list[T]
     total: int
     page: int

--- a/pyskoob/models/publisher.py
+++ b/pyskoob/models/publisher.py
@@ -2,6 +2,22 @@ from pydantic import BaseModel, Field
 
 
 class PublisherStats(BaseModel):
+    """Aggregated statistics about a publisher.
+
+    Attributes
+    ----------
+    followers : int | None
+        Number of users following the publisher.
+    average_rating : float | None
+        Average rating across the publisher's books.
+    ratings : int | None
+        Total number of ratings received.
+    male_percentage : int | None
+        Percentage of male readers.
+    female_percentage : int | None
+        Percentage of female readers.
+    """
+
     followers: int | None = None
     average_rating: float | None = None
     ratings: int | None = None
@@ -10,18 +26,60 @@ class PublisherStats(BaseModel):
 
 
 class PublisherItem(BaseModel):
+    """Book entry in a publisher listing.
+
+    Attributes
+    ----------
+    url : str
+        Link to the book's page.
+    title : str
+        Title of the book.
+    img_url : str
+        URL to the book cover image.
+    """
+
     url: str
     title: str
     img_url: str
 
 
 class PublisherAuthor(BaseModel):
+    """Author associated with a publisher.
+
+    Attributes
+    ----------
+    url : str
+        Link to the author's profile.
+    name : str
+        Author's name.
+    img_url : str
+        URL to the author's photo.
+    """
+
     url: str
     name: str
     img_url: str
 
 
 class Publisher(BaseModel):
+    """Detailed information about a publisher.
+
+    Attributes
+    ----------
+    id : int
+        Unique identifier of the publisher.
+    name : str
+        Publisher's display name.
+    description : str | None
+        Short description or history of the publisher.
+    website : str | None
+        URL to the publisher's official website.
+    stats : PublisherStats
+        Aggregated statistics about the publisher.
+    last_releases : list[PublisherItem]
+        Recently released books.
+    """
+
     id: int
     name: str
     description: str | None = None


### PR DESCRIPTION
## Summary
- document BaseSkoobService and AuthService
- add numpy-style docstrings to author and publisher data models
- document generic Pagination helper

## Testing
- `ruff format --check .`
- `ruff check .`
- `pytest -vv`
- `pre-commit run --all-files`


------
https://chatgpt.com/codex/tasks/task_e_689163046cd083298cb0becabe9c4c68

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive docstrings to key service and model classes, providing detailed descriptions of their purposes and attributes. This enhances code readability and helps users understand the structure and usage of authentication, pagination, author, and publisher-related classes. No changes were made to functionality or interfaces.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->