### PR TITLE
feat: add rate limiting to HTTP clients

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,22 @@ with SkoobClient() as client:
     print(me.name)
 ```
 
+## Rate limiting
+
+Skoob may block clients that issue too many requests in a short period of
+time. PySkoob includes a basic rate limiter that throttles requests to **one**
+per second by default. Adjusting this limit is possible but done entirely at
+your own risk—Skoob may block or ban your account. Provide a custom
+:class:`pyskoob.utils.RateLimiter` instance to change or disable the limit:
+
+```python
+from pyskoob import RateLimiter, SkoobClient
+
+limiter = RateLimiter(max_calls=2, period=1)  # two requests per second (use at your own risk)
+with SkoobClient(rate_limiter=limiter) as client:
+    ...
+```
+
 ## Running tests
 
 Install the project in editable mode and run the test suite:

--- a/pyskoob/__init__.py
+++ b/pyskoob/__init__.py
@@ -17,6 +17,7 @@ from .http.httpx import HttpxAsyncClient, HttpxSyncClient
 from .profile import SkoobProfileService
 from .publishers import PublisherService
 from .users import UserService
+from .utils import RateLimiter
 
 __all__ = [
     "AuthService",
@@ -30,5 +31,6 @@ __all__ = [
     "UserService",
     "models",
     "ParsingError",
+    "RateLimiter",
     "__version__",
 ]

--- a/pyskoob/client.py
+++ b/pyskoob/client.py
@@ -7,6 +7,7 @@ from pyskoob.http.httpx import HttpxSyncClient
 from pyskoob.profile import SkoobProfileService
 from pyskoob.publishers import PublisherService
 from pyskoob.users import UserService
+from pyskoob.utils import RateLimiter
 
 
 class SkoobClient:
@@ -18,11 +19,17 @@ class SkoobClient:
     ...     client.auth.login_with_cookies("token")
     """
 
-    def __init__(self):
+    def __init__(self, rate_limiter: RateLimiter | None = None) -> None:
+        """Initializes the SkoobClient.
+
+        Parameters
+        ----------
+        rate_limiter:
+            Optional rate limiter used to throttle requests. If ``None``, a
+            default limiter allowing one request per second is used.
         """
-        Initializes the SkoobClient.
-        """
-        self._client = HttpxSyncClient()
+
+        self._client = HttpxSyncClient(rate_limiter=rate_limiter)
         self.auth = AuthService(self._client)
         self.books = BookService(self._client)
         self.authors = AuthorService(self._client)

--- a/pyskoob/http/httpx.py
+++ b/pyskoob/http/httpx.py
@@ -7,6 +7,7 @@ from typing import Any
 
 import httpx
 
+from ..utils import RateLimiter
 from .client import AsyncHTTPClient, HTTPResponse, SyncHTTPClient
 
 
@@ -15,18 +16,25 @@ class HttpxSyncClient(SyncHTTPClient):
 
     Parameters
     ----------
-    **kwargs : Any
-        Optional arguments passed directly to ``httpx.Client``.
+    rate_limiter:
+        Optional rate limiter used to throttle requests. If not provided a
+        default limiter allowing one request per second is used.
+    **kwargs:
+        Additional arguments passed directly to ``httpx.Client``.
     """
 
-    def __init__(self, **kwargs: Any) -> None:
+    def __init__(self, rate_limiter: RateLimiter | None = None, **kwargs: Any) -> None:
         self._client = httpx.Client(**kwargs)
+        self._rate_limiter = rate_limiter or RateLimiter()
 
     @property
     def cookies(self) -> MutableMapping[str, Any]:
         return self._client.cookies
 
     def get(self, url: str, **kwargs: Any) -> HTTPResponse:
+        if not hasattr(self, "_rate_limiter"):
+            self._rate_limiter = RateLimiter()
+        self._rate_limiter.acquire()
         return self._client.get(url, **kwargs)
 
     def post(self, url: str, data: Any | None = None, **kwargs: Any) -> HTTPResponse:
@@ -49,6 +57,9 @@ class HttpxSyncClient(SyncHTTPClient):
             The HTTP response instance returned by ``httpx``.
         """
 
+        if not hasattr(self, "_rate_limiter"):
+            self._rate_limiter = RateLimiter()
+        self._rate_limiter.acquire()
         if isinstance(data, (str | bytes)):
             return self._client.post(url, content=data, **kwargs)
 
@@ -63,18 +74,25 @@ class HttpxAsyncClient(AsyncHTTPClient):
 
     Parameters
     ----------
-    **kwargs : Any
-        Optional arguments passed directly to ``httpx.AsyncClient``.
+    rate_limiter:
+        Optional rate limiter used to throttle requests. If not provided a
+        default limiter allowing one request per second is used.
+    **kwargs:
+        Additional arguments passed directly to ``httpx.AsyncClient``.
     """
 
-    def __init__(self, **kwargs: Any) -> None:
+    def __init__(self, rate_limiter: RateLimiter | None = None, **kwargs: Any) -> None:
         self._client = httpx.AsyncClient(**kwargs)
+        self._rate_limiter = rate_limiter or RateLimiter()
 
     @property
     def cookies(self) -> MutableMapping[str, Any]:
         return self._client.cookies
 
     async def get(self, url: str, **kwargs: Any) -> HTTPResponse:
+        if not hasattr(self, "_rate_limiter"):
+            self._rate_limiter = RateLimiter()
+        await self._rate_limiter.acquire_async()
         return await self._client.get(url, **kwargs)
 
     async def post(self, url: str, data: Any | None = None, **kwargs: Any) -> HTTPResponse:
@@ -97,6 +115,9 @@ class HttpxAsyncClient(AsyncHTTPClient):
             The HTTP response instance returned by ``httpx``.
         """
 
+        if not hasattr(self, "_rate_limiter"):
+            self._rate_limiter = RateLimiter()
+        await self._rate_limiter.acquire_async()
         if isinstance(data, (str | bytes)):
             return await self._client.post(url, content=data, **kwargs)
 

--- a/pyskoob/utils/__init__.py
+++ b/pyskoob/utils/__init__.py
@@ -1,0 +1,5 @@
+"""Utility helpers used throughout the project."""
+
+from .rate_limiter import RateLimiter
+
+__all__ = ["RateLimiter"]

--- a/pyskoob/utils/rate_limiter.py
+++ b/pyskoob/utils/rate_limiter.py
@@ -1,0 +1,63 @@
+from __future__ import annotations
+
+"""Utilities for throttling requests to the Skoob API."""
+
+import asyncio
+import time
+from collections import deque
+from threading import Lock
+
+
+class RateLimiter:
+    """Enforce a maximum number of calls within a time window.
+
+    Parameters
+    ----------
+    max_calls:
+        Maximum number of allowed calls within the given ``period``.
+        Defaults to ``1``.
+    period:
+        Time window in seconds in which ``max_calls`` are permitted.
+        Defaults to ``1.0``.
+
+    Notes
+    -----
+    The limiter is thread-safe and provides both synchronous and asynchronous
+    acquire methods. The asynchronous variant uses :func:`asyncio.sleep` to
+    avoid blocking the event loop.
+    """
+
+    def __init__(self, max_calls: int = 1, period: float = 1.0) -> None:
+        self._max_calls = max_calls
+        self._period = period
+        self._calls: deque[float] = deque()
+        self._lock = Lock()
+        self._async_lock = asyncio.Lock()
+
+    def _trim(self, now: float) -> None:
+        while self._calls and now - self._calls[0] >= self._period:
+            self._calls.popleft()
+
+    def acquire(self) -> None:
+        """Block until the next call is permitted."""
+        with self._lock:
+            now = time.monotonic()
+            self._trim(now)
+            if len(self._calls) >= self._max_calls:
+                sleep_for = self._period - (now - self._calls[0])
+                time.sleep(sleep_for)
+                now = time.monotonic()
+                self._trim(now)
+            self._calls.append(now)
+
+    async def acquire_async(self) -> None:
+        """Asynchronous variant of :meth:`acquire`."""
+        async with self._async_lock:
+            now = time.monotonic()
+            self._trim(now)
+            if len(self._calls) >= self._max_calls:
+                sleep_for = self._period - (now - self._calls[0])
+                await asyncio.sleep(sleep_for)
+                now = time.monotonic()
+                self._trim(now)
+            self._calls.append(now)

--- a/tests/test_rate_limiter.py
+++ b/tests/test_rate_limiter.py
@@ -1,0 +1,35 @@
+import asyncio
+import time
+
+from pyskoob.utils import RateLimiter
+
+
+def test_rate_limiter_blocks_synchronously() -> None:
+    limiter = RateLimiter(max_calls=2, period=0.05)
+    start = time.monotonic()
+    for _ in range(3):
+        limiter.acquire()
+    elapsed = time.monotonic() - start
+    assert elapsed >= 0.05
+
+
+def test_rate_limiter_blocks_asynchronously() -> None:
+    limiter = RateLimiter(max_calls=2, period=0.05)
+
+    async def run() -> float:
+        start = time.monotonic()
+        for _ in range(3):
+            await limiter.acquire_async()
+        return time.monotonic() - start
+
+    elapsed = asyncio.run(run())
+    assert elapsed >= 0.05
+
+
+def test_rate_limiter_default_is_one_per_second() -> None:
+    limiter = RateLimiter()
+    start = time.monotonic()
+    limiter.acquire()
+    limiter.acquire()
+    elapsed = time.monotonic() - start
+    assert elapsed >= 1.0


### PR DESCRIPTION
## Summary
- add thread-safe RateLimiter utility
- throttle requests in Httpx clients and expose in SkoobClient
- document default request limits
- default to one request per second and warn about increasing the rate

## Testing
- `ruff format --check .`
- `ruff check .`
- `pytest -vv`
- `pre-commit run --all-files`


------
https://chatgpt.com/codex/tasks/task_e_689165e25e748329b3df530999b97162