### PR TITLE
docs: document base service attributes

### DIFF
--- a/pyskoob/internal/base.py
+++ b/pyskoob/internal/base.py
@@ -10,9 +10,9 @@ class BaseHttpService:
 
     Attributes
     ----------
-    _base_url : str
+    base_url : str
         The base URL for the service.
-    _client : SyncHTTPClient
+    client : SyncHTTPClient
         The HTTP client for making requests.
     """
 
@@ -80,6 +80,13 @@ class BaseHttpService:
 
 class BaseSkoobService(BaseHttpService):
     """Base class for services that talk to the Skoob website.
+
+    Attributes
+    ----------
+    base_url : str
+        The base URL for Skoob endpoints.
+    client : SyncHTTPClient
+        The HTTP client used for requests.
 
     Notes
     -----


### PR DESCRIPTION
## Summary
- document `base_url` and `client` in `BaseHttpService`
- add matching Attributes section to `BaseSkoobService`

## Testing
- `ruff format .`
- `ruff check .`
- `pytest -vv`
- `pre-commit run --all-files`


------
https://chatgpt.com/codex/tasks/task_e_6891743b8068832993e694e840b1ec1a