### PR TITLE
docs: document exceptions for login_with_cookies

### DIFF
--- a/pyskoob/auth.py
+++ b/pyskoob/auth.py
@@ -50,6 +50,13 @@ class AuthService(BaseSkoobService):
         User
             The authenticated user's information.
 
+        Raises
+        ------
+        ConnectionError
+            If retrieving user information fails.
+        PermissionError
+            If the provided session token is invalid or expired.
+
         Examples
         --------
         >>> service.login_with_cookies("PHPSESSID=abc123")


### PR DESCRIPTION
## Summary
- document connection and permission errors for `login_with_cookies`

## Testing
- `pre-commit run --all-files`
- `pytest -vv`


------
https://chatgpt.com/codex/tasks/task_e_6891743bb5788329b4c989aea46d01b1