### PR TITLE
feat: allow configuring async client

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,6 +113,17 @@ with SkoobClient(rate_limiter=limiter) as client:
     ...
 ```
 
+``SkoobAsyncClient`` accepts the same configuration options and forwards any
+extra keyword arguments to ``httpx.AsyncClient``:
+
+```python
+from pyskoob import RateLimiter, SkoobAsyncClient
+
+limiter = RateLimiter(max_calls=2, period=1)
+async with SkoobAsyncClient(rate_limiter=limiter, timeout=5) as client:
+    ...
+```
+
 ## Running tests
 
 Install the project in editable mode and run the test suite:

--- a/pyskoob/client.py
+++ b/pyskoob/client.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from typing import Any
+
 from pyskoob.auth import AsyncAuthService, AuthService
 from pyskoob.authors import AsyncAuthorService, AuthorService
 from pyskoob.books import AsyncBookService, BookService
@@ -82,10 +84,19 @@ class SkoobClient:
 
 
 class SkoobAsyncClient:
-    """Facade for interacting with Skoob services asynchronously."""
+    """Facade for interacting with Skoob services asynchronously.
 
-    def __init__(self):
-        self._client = HttpxAsyncClient()
+    Parameters
+    ----------
+    rate_limiter:
+        Optional rate limiter used to throttle requests. If ``None``, a
+        default limiter allowing one request per second is used.
+    **client_kwargs:
+        Additional keyword arguments forwarded to ``httpx.AsyncClient``.
+    """
+
+    def __init__(self, rate_limiter: RateLimiter | None = None, **client_kwargs: Any) -> None:
+        self._client = HttpxAsyncClient(rate_limiter=rate_limiter, **client_kwargs)
         self.auth = AsyncAuthService(self._client)
         self.books = AsyncBookService(self._client)
         self.authors = AsyncAuthorService(self._client)

--- a/tests/test_skoob_async_client.py
+++ b/tests/test_skoob_async_client.py
@@ -1,6 +1,7 @@
+import httpx
 import pytest
 
-from pyskoob import SkoobAsyncClient
+from pyskoob import RateLimiter, SkoobAsyncClient
 
 pytestmark = pytest.mark.anyio
 
@@ -23,3 +24,10 @@ async def test_async_client_context_manager(monkeypatch, anyio_backend):
         assert client.auth
         assert client.books
     assert closed
+
+
+async def test_async_client_allows_configuration(anyio_backend):
+    limiter = RateLimiter()
+    async with SkoobAsyncClient(rate_limiter=limiter, timeout=5) as client:
+        assert client._client._rate_limiter is limiter
+        assert client._client._client.timeout == httpx.Timeout(5)


### PR DESCRIPTION
## Summary
- allow injecting a rate limiter and httpx.AsyncClient kwargs into `SkoobAsyncClient`
- document async client configuration in README
- add coverage for new async client options

## Testing
- `pre-commit run --files pyskoob/client.py tests/test_skoob_async_client.py README.md`
- `pytest -vv`


------
https://chatgpt.com/codex/tasks/task_e_6891dc93bcbc83299b3a87eaf0f1ef3d

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the README to include usage and configuration details for the asynchronous client, with example code for custom rate limiting and timeouts.

* **New Features**
  * Enhanced the asynchronous client to support custom rate limiter and additional configuration options.

* **Tests**
  * Added tests to verify that the asynchronous client correctly applies custom configuration options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->