### PR TITLE
refactor: convert async login validation to coroutine

### DIFF
--- a/pyskoob/auth.py
+++ b/pyskoob/auth.py
@@ -230,7 +230,15 @@ class AsyncAuthService(AsyncBaseSkoobService):  # pragma: no cover - thin async 
         logger.info("Successfully retrieved user: '%s'", user.name)
         return user
 
-    def validate_login(self) -> None:
+    async def validate_login(self) -> None:
+        """Validate that the current session is authenticated.
+
+        Notes
+        -----
+        This method performs no I/O but remains asynchronous for API
+        consistency across async services.
+        """
+
         logger.debug("Validating login status.")
         if not self._is_logged_in:
             logger.warning("Validation failed: User is not logged in.")

--- a/pyskoob/internal/async_authenticated.py
+++ b/pyskoob/internal/async_authenticated.py
@@ -16,6 +16,6 @@ class AsyncAuthenticatedService(AsyncBaseSkoobService):  # pragma: no cover - th
         super().__init__(client)
         self._auth_service = auth_service
 
-    def _validate_login(self) -> None:
+    async def _validate_login(self) -> None:
         """Ensure the current session is authenticated."""
-        self._auth_service.validate_login()
+        await self._auth_service.validate_login()

--- a/pyskoob/profile.py
+++ b/pyskoob/profile.py
@@ -208,42 +208,42 @@ class AsyncSkoobProfileService(AsyncAuthenticatedService):  # pragma: no cover -
         super().__init__(client, auth_service)
 
     async def add_book_label(self, edition_id: int, label: BookLabel) -> bool:
-        self._validate_login()
+        await self._validate_login()
         url = f"{self.base_url}/v1/label_add/{edition_id}/{label.value}"
         response = await self.client.get(url)
         response.raise_for_status()
         return response.json().get("success", False)
 
     async def remove_book_label(self, edition_id: int) -> bool:
-        self._validate_login()
+        await self._validate_login()
         url = f"{self.base_url}/v1/label_del/{edition_id}"
         response = await self.client.get(url)
         response.raise_for_status()
         return response.json().get("success", False)
 
     async def update_book_status(self, edition_id: int, status: BookStatus) -> bool:
-        self._validate_login()
+        await self._validate_login()
         url = f"{self.base_url}/v1/shelf_add/{edition_id}/{status.value}"
         response = await self.client.get(url)
         response.raise_for_status()
         return response.json().get("success", False)
 
     async def remove_book_status(self, edition_id: int) -> bool:
-        self._validate_login()
+        await self._validate_login()
         url = f"{self.base_url}/v1/shelf_del/{edition_id}"
         response = await self.client.get(url)
         response.raise_for_status()
         return response.json().get("success", False)
 
     async def change_book_shelf(self, edition_id: int, bookshelf: BookShelf) -> bool:
-        self._validate_login()
+        await self._validate_login()
         url = f"{self.base_url}/estante/prateleira/{edition_id}/{bookshelf.value}"
         response = await self.client.get(url)
         response.raise_for_status()
         return response.json().get("success", False)
 
     async def rate_book(self, edition_id: int, ranking: float) -> bool:
-        self._validate_login()
+        await self._validate_login()
         if not (0 <= ranking <= 5):
             raise ValueError("Rating must be between 0 and 5.")
         url = f"{self.base_url}/v1/book_rate/{edition_id}/{ranking}"

--- a/pyskoob/users.py
+++ b/pyskoob/users.py
@@ -455,7 +455,7 @@ class AsyncUserService(AsyncAuthenticatedService):  # pragma: no cover - thin as
         FileNotFoundError
             If the user with the given ID is not found.
         """
-        self._validate_login()
+        await self._validate_login()
         logger.info(f"Getting user by id: {user_id}")
         url = f"{self.base_url}/v1/user/{user_id}/stats:true"
         response = await self.client.get(url)
@@ -492,7 +492,7 @@ class AsyncUserService(AsyncAuthenticatedService):  # pragma: no cover - thin as
         ParsingError
             If the HTML structure of the page changes and parsing fails.
         """
-        self._validate_login()
+        await self._validate_login()
         url = f"{self.base_url}/{relation.value}/listar/{user_id}/page:{page}/limit:100"
         logger.info(f"Getting '{relation.value}' for user_id: {user_id}, page: {page}")
         response = await self.client.get(url)
@@ -534,7 +534,7 @@ class AsyncUserService(AsyncAuthenticatedService):  # pragma: no cover - thin as
         ParsingError
             If the HTML structure of the page changes and parsing fails.
         """
-        self._validate_login()
+        await self._validate_login()
         url = f"{self.base_url}/estante/resenhas/{user_id}/mpage:{page}/limit:50"
         logger.info(f"Getting reviews for user_id: {user_id}, page: {page}")
         response = await self.client.get(url)
@@ -602,7 +602,7 @@ class AsyncUserService(AsyncAuthenticatedService):  # pragma: no cover - thin as
         UserReadStats
             The user's reading statistics.
         """
-        self._validate_login()
+        await self._validate_login()
         logger.info(f"Getting read stats for user_id: {user_id}")
         url = f"{self.base_url}/v1/meta_stats/{user_id}"
         response = await self.client.get(url)
@@ -639,7 +639,7 @@ class AsyncUserService(AsyncAuthenticatedService):  # pragma: no cover - thin as
         Pagination[UserBook]
             A paginated list of books in the user's bookcase.
         """
-        self._validate_login()
+        await self._validate_login()
         url = f"{self.base_url}/v1/bookcase/books/{user_id}/shelf_id:{bookcase_option.value}/page:{page}/limit:100"
         logger.info(f"Getting bookcase for user_id: {user_id}, option: '{bookcase_option.name}', page: {page}")
         response = await self.client.get(url)
@@ -706,7 +706,7 @@ class AsyncUserService(AsyncAuthenticatedService):  # pragma: no cover - thin as
         ParsingError
             If the HTML structure is invalid or parsing fails.
         """
-        self._validate_login()
+        await self._validate_login()
         url = f"{self.base_url}/usuario/lista/busca:{query}/mpage:{page}/limit:{limit}"
         if gender:
             url += f"/sexo:{gender.value}"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,8 +3,8 @@ from typing import Any, cast
 
 import pytest
 
-from pyskoob.auth import AuthService
-from pyskoob.http.client import SyncHTTPClient
+from pyskoob.auth import AsyncAuthService, AuthService
+from pyskoob.http.client import AsyncHTTPClient, SyncHTTPClient
 from pyskoob.models.user import User
 
 
@@ -45,14 +45,43 @@ class DummyClient:
         pass
 
 
+class DummyAsyncClient:
+    def __init__(self, text: str = "", json_data: Any | None = None):
+        self.text = text
+        self.json_data = json_data or {}
+        self.cookies: dict[str, Any] = {}
+        self.called: list[Any] = []
+
+    async def get(self, url: str, **_: Any) -> DummyResponse:
+        self.called.append(url)
+        return DummyResponse(self.text, self.json_data)
+
+    async def post(self, url: str, data: Any | None = None, **_: Any) -> DummyResponse:
+        self.called.append(url)
+        return DummyResponse(self.text, self.json_data)
+
+    async def close(self) -> None:  # pragma: no cover - simple stub
+        pass
+
+
 @pytest.fixture
 def dummy_client() -> DummyClient:
     return DummyClient()
 
 
 @pytest.fixture
+def dummy_async_client() -> DummyAsyncClient:
+    return DummyAsyncClient()
+
+
+@pytest.fixture
 def dummy_auth(dummy_client: DummyClient) -> AuthService:
     return AuthService(cast(SyncHTTPClient, dummy_client))
+
+
+@pytest.fixture
+def dummy_async_auth(dummy_async_client: DummyAsyncClient) -> AsyncAuthService:
+    return AsyncAuthService(cast(AsyncHTTPClient, dummy_async_client))
 
 
 @pytest.fixture

--- a/tests/test_async_auth_service.py
+++ b/tests/test_async_auth_service.py
@@ -1,0 +1,15 @@
+import pytest
+
+pytestmark = pytest.mark.anyio
+
+
+@pytest.fixture
+def anyio_backend() -> str:
+    return "asyncio"
+
+
+async def test_validate_login(dummy_async_auth):
+    with pytest.raises(PermissionError):
+        await dummy_async_auth.validate_login()
+    dummy_async_auth._is_logged_in = True
+    await dummy_async_auth.validate_login()


### PR DESCRIPTION
## Summary
- turn `AsyncAuthService.validate_login` into a coroutine for API consistency
- ensure async services await login validation
- cover async login validation with a new test

## Testing
- `pre-commit run --all-files`
- `pytest -vv`


------
https://chatgpt.com/codex/tasks/task_e_6891dc84ebbc832986e7adf8bc1f6154