### PR TITLE
docs: add missing numpy-style docstrings

### DIFF
--- a/pyskoob/auth.py
+++ b/pyskoob/auth.py
@@ -1,3 +1,5 @@
+"""Authentication helpers and session management for Skoob."""
+
 import logging
 
 from pyskoob.http.client import AsyncHTTPClient, SyncHTTPClient
@@ -185,6 +187,19 @@ class AsyncAuthService(AsyncBaseSkoobService):  # pragma: no cover - thin async 
         self._is_logged_in = False
 
     async def login_with_cookies(self, session_token: str) -> User:
+        """Log in using a pre-existing session token.
+
+        Parameters
+        ----------
+        session_token : str
+            The PHPSESSID token from Skoob.
+
+        Returns
+        -------
+        User
+            The authenticated user's information.
+        """
+
         logger.info("Attempting to log in with session token.")
         self.client.cookies.update({"PHPSESSID": session_token})
         user = await self.get_my_info()
@@ -193,6 +208,21 @@ class AsyncAuthService(AsyncBaseSkoobService):  # pragma: no cover - thin async 
         return user
 
     async def login(self, email: str, password: str) -> User:
+        """Log in using email and password.
+
+        Parameters
+        ----------
+        email : str
+            The user's email address.
+        password : str
+            The user's password.
+
+        Returns
+        -------
+        User
+            The authenticated user's information.
+        """
+
         logger.info("Attempting to log in with email and password.")
         url = f"{self.base_url}/v1/login"
         data = {
@@ -216,6 +246,14 @@ class AsyncAuthService(AsyncBaseSkoobService):  # pragma: no cover - thin async 
         return user
 
     async def get_my_info(self) -> User:
+        """Retrieve information about the authenticated user.
+
+        Returns
+        -------
+        User
+            The authenticated user's information.
+        """
+
         logger.info("Getting authenticated user's information.")
         url = f"{self.base_url}/v1/user/stats:true"
         response = await self.client.get(url)
@@ -231,6 +269,14 @@ class AsyncAuthService(AsyncBaseSkoobService):  # pragma: no cover - thin async 
         return user
 
     def validate_login(self) -> None:
+        """Validate whether the current session is authenticated.
+
+        Raises
+        ------
+        PermissionError
+            If the user is not logged in.
+        """
+
         logger.debug("Validating login status.")
         if not self._is_logged_in:
             logger.warning("Validation failed: User is not logged in.")

--- a/pyskoob/authors.py
+++ b/pyskoob/authors.py
@@ -1,3 +1,5 @@
+"""Services for retrieving authors and their works from Skoob."""
+
 import logging
 
 from pyskoob.exceptions import ParsingError
@@ -159,6 +161,21 @@ class AsyncAuthorService(AsyncBaseSkoobService):  # pragma: no cover - thin asyn
         super().__init__(client)
 
     async def search(self, query: str, page: int = 1) -> Pagination[AuthorSearchResult]:
+        """Asynchronously search for authors by name.
+
+        Parameters
+        ----------
+        query : str
+            Term to look for.
+        page : int, optional
+            Page number for pagination, by default ``1``.
+
+        Returns
+        -------
+        Pagination[AuthorSearchResult]
+            Paginated list of authors matching the query.
+        """
+
         url = f"{self.base_url}/autor/lista/busca:{query}/mpage:{page}"
         logger.info("Searching authors with query '%s' page %s", query, page)
         try:
@@ -191,6 +208,19 @@ class AsyncAuthorService(AsyncBaseSkoobService):  # pragma: no cover - thin asyn
             )
 
     async def get_by_id(self, author_id: int) -> AuthorProfile:
+        """Fetch an author's profile by identifier.
+
+        Parameters
+        ----------
+        author_id : int
+            Identifier of the author on Skoob.
+
+        Returns
+        -------
+        AuthorProfile
+            Structured profile data for the requested author.
+        """
+
         url = f"{self.base_url}/autor/{author_id}"
         logger.info("Fetching author profile: %s", url)
         try:
@@ -203,6 +233,21 @@ class AsyncAuthorService(AsyncBaseSkoobService):  # pragma: no cover - thin asyn
             raise ParsingError("Failed to fetch author profile.") from exc
 
     async def get_books(self, author_id: int, page: int = 1) -> Pagination[BookSearchResult]:
+        """Fetch books written by the given author.
+
+        Parameters
+        ----------
+        author_id : int
+            The author identifier.
+        page : int, optional
+            Pagination page, by default ``1``.
+
+        Returns
+        -------
+        Pagination[BookSearchResult]
+            Paginated list of books authored by the given ID.
+        """
+
         url = f"{self.base_url}/autor/livros/{author_id}/page:{page}"
         logger.info("Fetching books for author %s page %s", author_id, page)
         try:

--- a/pyskoob/books.py
+++ b/pyskoob/books.py
@@ -1,3 +1,5 @@
+"""Services for searching and retrieving books from Skoob."""
+
 import logging
 import re
 
@@ -308,6 +310,23 @@ class AsyncBookService(AsyncBaseSkoobService):  # pragma: no cover - thin async 
         super().__init__(client)
 
     async def search(self, query: str, search_by: BookSearch = BookSearch.TITLE, page: int = 1) -> Pagination[BookSearchResult]:
+        """Asynchronously search for books by query and type.
+
+        Parameters
+        ----------
+        query : str
+            The search query string.
+        search_by : BookSearch, optional
+            Type of search (title, author, etc.), by default ``BookSearch.TITLE``.
+        page : int, optional
+            Page number for pagination, by default ``1``.
+
+        Returns
+        -------
+        Pagination[BookSearchResult]
+            Paginated list of search results.
+        """
+
         url = f"{self.base_url}/livro/lista/busca:{query}/tipo:{search_by.value}/mpage:{page}"
         logger.info("Searching for books with query: '%s' on page %s", query, page)
         try:
@@ -346,6 +365,19 @@ class AsyncBookService(AsyncBaseSkoobService):  # pragma: no cover - thin async 
             )
 
     async def get_by_id(self, edition_id: int) -> Book:
+        """Retrieve a book by its edition ID asynchronously.
+
+        Parameters
+        ----------
+        edition_id : int
+            The edition identifier of the book.
+
+        Returns
+        -------
+        Book
+            The book details for the given edition.
+        """
+
         logger.info("Getting book by edition_id: %s", edition_id)
         url = f"{self.base_url}/v1/book/{edition_id}/stats:true"
         try:
@@ -377,6 +409,23 @@ class AsyncBookService(AsyncBaseSkoobService):  # pragma: no cover - thin async 
             raise ParsingError("Failed to retrieve book.") from exc
 
     async def get_reviews(self, book_id: int, edition_id: int | None = None, page: int = 1) -> Pagination[BookReview]:
+        """Retrieve book reviews asynchronously.
+
+        Parameters
+        ----------
+        book_id : int
+            Identifier of the book.
+        edition_id : int, optional
+            Specific edition to filter reviews, by default ``None``.
+        page : int, optional
+            Pagination page, by default ``1``.
+
+        Returns
+        -------
+        Pagination[BookReview]
+            Paginated list of book reviews.
+        """
+
         url = f"{self.base_url}/livro/resenhas/{book_id}/mpage:{page}/limit:50"
         if edition_id:
             url += f"/edition:{edition_id}"
@@ -418,6 +467,27 @@ class AsyncBookService(AsyncBaseSkoobService):  # pragma: no cover - thin async 
         limit: int = 500,
         page: int = 1,
     ) -> Pagination[int]:
+        """Retrieve user IDs who marked the book with a given status.
+
+        Parameters
+        ----------
+        book_id : int
+            Identifier of the book.
+        status : BookUserStatus
+            User status to filter by (read, reading, etc.).
+        edition_id : int, optional
+            Specific edition to filter, by default ``None``.
+        limit : int, optional
+            Maximum number of users per page, by default ``500``.
+        page : int, optional
+            Page number for pagination, by default ``1``.
+
+        Returns
+        -------
+        Pagination[int]
+            Paginated list of user IDs.
+        """
+
         url = f"{self.base_url}/livro/leitores/{status.value}/{book_id}/limit:{limit}/page:{page}"
         if edition_id:
             url += f"/edition:{edition_id}"

--- a/pyskoob/client.py
+++ b/pyskoob/client.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+"""Client facades bundling synchronous and asynchronous services."""
+
 from pyskoob.auth import AsyncAuthService, AuthService
 from pyskoob.authors import AsyncAuthorService, AuthorService
 from pyskoob.books import AsyncBookService, BookService

--- a/pyskoob/exceptions.py
+++ b/pyskoob/exceptions.py
@@ -1,3 +1,6 @@
+"""Project-wide custom exceptions."""
+
+
 class ParsingError(Exception):
     """Custom exception for errors during HTML parsing."""
 

--- a/pyskoob/internal/async_authenticated.py
+++ b/pyskoob/internal/async_authenticated.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+"""Authentication-aware base classes for async services."""
+
 from typing import TYPE_CHECKING
 
 from pyskoob.http.client import AsyncHTTPClient

--- a/pyskoob/internal/async_base.py
+++ b/pyskoob/internal/async_base.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+"""Base classes for asynchronous Skoob HTTP services."""
+
 from bs4 import BeautifulSoup
 
 from pyskoob.http.client import AsyncHTTPClient

--- a/pyskoob/internal/base.py
+++ b/pyskoob/internal/base.py
@@ -1,3 +1,5 @@
+"""Base classes for synchronous Skoob HTTP services."""
+
 from bs4 import BeautifulSoup
 
 from pyskoob.http.client import SyncHTTPClient

--- a/pyskoob/models/author.py
+++ b/pyskoob/models/author.py
@@ -1,3 +1,5 @@
+"""Pydantic models representing authors and related data."""
+
 from pydantic import BaseModel, ConfigDict, Field
 
 

--- a/pyskoob/models/book.py
+++ b/pyskoob/models/book.py
@@ -1,3 +1,5 @@
+"""Pydantic models representing books and their statistics."""
+
 from datetime import datetime
 
 from pydantic import BaseModel, ConfigDict, Field

--- a/pyskoob/models/pagination.py
+++ b/pyskoob/models/pagination.py
@@ -1,3 +1,5 @@
+"""Generic pagination model used across services."""
+
 from typing import Generic, TypeVar
 
 from pydantic import BaseModel

--- a/pyskoob/models/publisher.py
+++ b/pyskoob/models/publisher.py
@@ -1,3 +1,5 @@
+"""Pydantic models for publisher information and related data."""
+
 from pydantic import BaseModel, Field
 
 

--- a/pyskoob/models/user.py
+++ b/pyskoob/models/user.py
@@ -1,3 +1,5 @@
+"""Pydantic models representing Skoob users and related data."""
+
 from datetime import datetime
 
 from pydantic import BaseModel, ConfigDict, Field, HttpUrl

--- a/pyskoob/parsers/publishers.py
+++ b/pyskoob/parsers/publishers.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+"""Parser helpers for publisher-related pages on Skoob."""
+
 from bs4 import Tag
 
 from pyskoob.models.publisher import PublisherAuthor, PublisherItem, PublisherStats
@@ -7,6 +9,23 @@ from pyskoob.utils.bs4_utils import get_tag_attr, get_tag_text, safe_find
 
 
 def parse_stats(div: Tag | None) -> PublisherStats:
+    """Parse follower, rating and gender statistics for a publisher.
+
+    The stats block displays follower counts, average rating with total
+    evaluations and the male/female reader percentages. Missing elements are
+    represented as ``None`` in the returned dataclass.
+
+    Parameters
+    ----------
+    div : Tag or None
+        Container with the statistics section.
+
+    Returns
+    -------
+    PublisherStats
+        Dataclass populated with the extracted values.
+    """
+
     if not div:
         return PublisherStats()  # pragma: no cover - default empty stats
     followers = avg = ratings = male = female = None
@@ -40,6 +59,24 @@ def parse_stats(div: Tag | None) -> PublisherStats:
 
 
 def parse_book(div: Tag, base_url: str) -> PublisherItem:
+    """Parse a book entry listed on a publisher page.
+
+    Each book block contains an anchor with the book link and an ``img`` tag
+    for the cover. Only the URL, title and image URL are captured.
+
+    Parameters
+    ----------
+    div : Tag
+        Container representing a single book.
+    base_url : str
+        Base URL used to expand the book link.
+
+    Returns
+    -------
+    PublisherItem
+        Lightweight representation of the book.
+    """
+
     anchor = safe_find(div, "a")
     img_tag = safe_find(anchor, "img")
     return PublisherItem(
@@ -50,6 +87,25 @@ def parse_book(div: Tag, base_url: str) -> PublisherItem:
 
 
 def parse_author(div: Tag, base_url: str) -> PublisherAuthor:
+    """Parse an author entry from a publisher page.
+
+    The entry includes a link with the author's profile image and a heading
+    containing the name. The parser returns the absolute profile URL, author
+    name and image URL.
+
+    Parameters
+    ----------
+    div : Tag
+        Container representing a single author.
+    base_url : str
+        Base URL used to expand the author link.
+
+    Returns
+    -------
+    PublisherAuthor
+        Structured author information extracted from the block.
+    """
+
     anchor = safe_find(div, "a")
     name_tag = safe_find(div, "h3")
     img_tag = safe_find(anchor, "img")

--- a/pyskoob/profile.py
+++ b/pyskoob/profile.py
@@ -1,3 +1,5 @@
+"""Profile management helpers for authenticated Skoob users."""
+
 import logging
 
 from pyskoob.auth import AsyncAuthService, AuthService
@@ -208,6 +210,21 @@ class AsyncSkoobProfileService(AsyncAuthenticatedService):  # pragma: no cover -
         super().__init__(client, auth_service)
 
     async def add_book_label(self, edition_id: int, label: BookLabel) -> bool:
+        """Add a label to a book in the authenticated profile.
+
+        Parameters
+        ----------
+        edition_id : int
+            The edition identifier.
+        label : BookLabel
+            Label to apply to the book.
+
+        Returns
+        -------
+        bool
+            ``True`` if the operation succeeded.
+        """
+
         self._validate_login()
         url = f"{self.base_url}/v1/label_add/{edition_id}/{label.value}"
         response = await self.client.get(url)
@@ -215,6 +232,19 @@ class AsyncSkoobProfileService(AsyncAuthenticatedService):  # pragma: no cover -
         return response.json().get("success", False)
 
     async def remove_book_label(self, edition_id: int) -> bool:
+        """Remove a label from a book in the authenticated profile.
+
+        Parameters
+        ----------
+        edition_id : int
+            The edition identifier.
+
+        Returns
+        -------
+        bool
+            ``True`` if the operation succeeded.
+        """
+
         self._validate_login()
         url = f"{self.base_url}/v1/label_del/{edition_id}"
         response = await self.client.get(url)
@@ -222,6 +252,21 @@ class AsyncSkoobProfileService(AsyncAuthenticatedService):  # pragma: no cover -
         return response.json().get("success", False)
 
     async def update_book_status(self, edition_id: int, status: BookStatus) -> bool:
+        """Update the user's status for a book.
+
+        Parameters
+        ----------
+        edition_id : int
+            The edition identifier.
+        status : BookStatus
+            New status to assign to the book.
+
+        Returns
+        -------
+        bool
+            ``True`` if the status update succeeded.
+        """
+
         self._validate_login()
         url = f"{self.base_url}/v1/shelf_add/{edition_id}/{status.value}"
         response = await self.client.get(url)
@@ -229,6 +274,19 @@ class AsyncSkoobProfileService(AsyncAuthenticatedService):  # pragma: no cover -
         return response.json().get("success", False)
 
     async def remove_book_status(self, edition_id: int) -> bool:
+        """Remove the user's status for a book.
+
+        Parameters
+        ----------
+        edition_id : int
+            The edition identifier.
+
+        Returns
+        -------
+        bool
+            ``True`` if the status was removed successfully.
+        """
+
         self._validate_login()
         url = f"{self.base_url}/v1/shelf_del/{edition_id}"
         response = await self.client.get(url)
@@ -236,6 +294,21 @@ class AsyncSkoobProfileService(AsyncAuthenticatedService):  # pragma: no cover -
         return response.json().get("success", False)
 
     async def change_book_shelf(self, edition_id: int, bookshelf: BookShelf) -> bool:
+        """Move a book to a different bookshelf.
+
+        Parameters
+        ----------
+        edition_id : int
+            The edition identifier.
+        bookshelf : BookShelf
+            Target bookshelf.
+
+        Returns
+        -------
+        bool
+            ``True`` if the operation succeeded.
+        """
+
         self._validate_login()
         url = f"{self.base_url}/estante/prateleira/{edition_id}/{bookshelf.value}"
         response = await self.client.get(url)
@@ -243,6 +316,28 @@ class AsyncSkoobProfileService(AsyncAuthenticatedService):  # pragma: no cover -
         return response.json().get("success", False)
 
     async def rate_book(self, edition_id: int, ranking: float) -> bool:
+        """Rate a book in the authenticated profile.
+
+        Parameters
+        ----------
+        edition_id : int
+            The edition identifier.
+        ranking : float
+            Rating between 0 and 5.
+
+        Returns
+        -------
+        bool
+            ``True`` if the rating was saved.
+
+        Raises
+        ------
+        ValueError
+            If ``ranking`` is outside the 0–5 range.
+        RuntimeError
+            If Skoob rejects the rating.
+        """
+
         self._validate_login()
         if not (0 <= ranking <= 5):
             raise ValueError("Rating must be between 0 and 5.")

--- a/pyskoob/publishers.py
+++ b/pyskoob/publishers.py
@@ -1,3 +1,5 @@
+"""Retrieve publisher information, books and authors from Skoob."""
+
 import logging
 from typing import cast
 
@@ -193,6 +195,19 @@ class AsyncPublisherService(AsyncBaseSkoobService):  # pragma: no cover - thin a
         super().__init__(client)
 
     async def get_by_id(self, publisher_id: int) -> Publisher:
+        """Retrieve detailed information about a publisher.
+
+        Parameters
+        ----------
+        publisher_id : int
+            The identifier of the publisher on Skoob.
+
+        Returns
+        -------
+        Publisher
+            Structured publisher information including stats and releases.
+        """
+
         url = f"{self.base_url}/editora/{publisher_id}"
         logger.info("Fetching publisher page: %s", url)
         try:
@@ -226,6 +241,21 @@ class AsyncPublisherService(AsyncBaseSkoobService):  # pragma: no cover - thin a
             raise ParsingError("An unexpected error occurred while parsing publisher page.") from exc
 
     async def get_authors(self, publisher_id: int, page: int = 1) -> Pagination[PublisherAuthor]:
+        """Retrieve authors associated with a publisher.
+
+        Parameters
+        ----------
+        publisher_id : int
+            The identifier of the publisher on Skoob.
+        page : int, optional
+            Pagination page, by default ``1``.
+
+        Returns
+        -------
+        Pagination[PublisherAuthor]
+            Paginated list of authors published by the publisher.
+        """
+
         url = f"{self.base_url}/editora/autores/{publisher_id}/mpage:{page}"
         logger.info("Fetching publisher authors: %s", url)
         try:
@@ -253,6 +283,21 @@ class AsyncPublisherService(AsyncBaseSkoobService):  # pragma: no cover - thin a
             raise ParsingError("An unexpected error occurred while parsing publisher authors.") from exc
 
     async def get_books(self, publisher_id: int, page: int = 1) -> Pagination[PublisherItem]:
+        """Retrieve books published by a given publisher.
+
+        Parameters
+        ----------
+        publisher_id : int
+            The identifier of the publisher on Skoob.
+        page : int, optional
+            Pagination page, by default ``1``.
+
+        Returns
+        -------
+        Pagination[PublisherItem]
+            Paginated list of books released by the publisher.
+        """
+
         url = f"{self.base_url}/editora/livros/{publisher_id}/mpage:{page}"
         logger.info("Fetching publisher books: %s", url)
         try:

--- a/pyskoob/users.py
+++ b/pyskoob/users.py
@@ -1,3 +1,5 @@
+"""Services for retrieving and manipulating Skoob user data."""
+
 import logging
 import re
 from datetime import datetime

--- a/pyskoob/utils/bs4_utils.py
+++ b/pyskoob/utils/bs4_utils.py
@@ -1,3 +1,5 @@
+"""Utilities for working safely with BeautifulSoup elements."""
+
 from typing import Any
 
 from bs4 import BeautifulSoup, Tag


### PR DESCRIPTION
## Summary
- add module and function docstrings using NumPy style
- document async service wrappers and HTML parser helpers
- expand parser docstrings with details on HTML structure and extracted fields

## Testing
- `ruff format --check .`
- `ruff check .`
- `pytest -vv`
- `pre-commit run --all-files`


------
https://chatgpt.com/codex/tasks/task_e_6891dae6118c8329a9ca6d2a67857f58