### PR TITLE
feat: add async context manager to HTTPX client

### DIFF
--- a/docs/advanced_usage.md
+++ b/docs/advanced_usage.md
@@ -33,10 +33,9 @@ import asyncio
 from pyskoob import HttpxAsyncClient
 
 async def main() -> None:
-    client = HttpxAsyncClient()
-    resp = await client.get("https://www.skoob.com.br")
-    print(resp.text[:100])
-    await client.close()
+    async with HttpxAsyncClient() as client:
+        resp = await client.get("https://www.skoob.com.br")
+        print(resp.text[:100])
 
 asyncio.run(main())
 ```

--- a/pyskoob/http/httpx.py
+++ b/pyskoob/http/httpx.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 """httpx-based implementations of the HTTP client protocols."""
 
 from collections.abc import MutableMapping
+from types import TracebackType
 from typing import Any
 
 import httpx
@@ -125,3 +126,36 @@ class HttpxAsyncClient(AsyncHTTPClient):
 
     async def close(self) -> None:
         await self._client.aclose()
+
+    async def __aenter__(self) -> HttpxAsyncClient:
+        """Enter the asynchronous context manager.
+
+        Returns
+        -------
+        HttpxAsyncClient
+            The initialized client instance.
+        """
+
+        return self
+
+    async def __aexit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc: BaseException | None,
+        tb: TracebackType | None,
+    ) -> None:
+        """Exit the asynchronous context manager.
+
+        Ensures the underlying HTTPX client is properly closed.
+
+        Parameters
+        ----------
+        exc_type:
+            Exception type raised within the ``async with`` block, if any.
+        exc:
+            The exception instance raised within the block, if any.
+        tb:
+            Traceback information, if an exception occurred.
+        """
+
+        await self.close()

--- a/tests/test_httpx_async_client.py
+++ b/tests/test_httpx_async_client.py
@@ -23,3 +23,18 @@ def test_async_client_get_post_aclose():
         await client.close()
 
     asyncio.run(main())
+
+
+def test_async_client_context_manager_closes():
+    async def handler(request: httpx.Request) -> httpx.Response:  # pragma: no cover - simple handler
+        return httpx.Response(200, text="ok")
+
+    async def main() -> None:
+        transport = httpx.MockTransport(handler)
+        client = HttpxAsyncClient(transport=transport)
+        async with client as ctx:
+            resp = await ctx.get("https://x")
+            assert resp.text == "ok"
+        assert client._client.is_closed
+
+    asyncio.run(main())


### PR DESCRIPTION
## Summary
- add `__aenter__` and `__aexit__` to `HttpxAsyncClient` for automatic cleanup
- document async context manager usage
- test `HttpxAsyncClient` context manager behavior

## Testing
- `ruff format --check .`
- `ruff check .`
- `pytest -vv`
- `pre-commit run --all-files`


------
https://chatgpt.com/codex/tasks/task_e_6891e21d88008329a8c1d16e5bbdd69d