### PR TITLE
refactor: remove redundant rate limiter checks

### DIFF
--- a/pyskoob/http/httpx.py
+++ b/pyskoob/http/httpx.py
@@ -32,8 +32,6 @@ class HttpxSyncClient(SyncHTTPClient):
         return self._client.cookies
 
     def get(self, url: str, **kwargs: Any) -> HTTPResponse:
-        if not hasattr(self, "_rate_limiter"):
-            self._rate_limiter = RateLimiter()
         self._rate_limiter.acquire()
         return self._client.get(url, **kwargs)
 
@@ -57,8 +55,6 @@ class HttpxSyncClient(SyncHTTPClient):
             The HTTP response instance returned by ``httpx``.
         """
 
-        if not hasattr(self, "_rate_limiter"):
-            self._rate_limiter = RateLimiter()
         self._rate_limiter.acquire()
         if isinstance(data, (str | bytes)):
             return self._client.post(url, content=data, **kwargs)
@@ -90,8 +86,6 @@ class HttpxAsyncClient(AsyncHTTPClient):
         return self._client.cookies
 
     async def get(self, url: str, **kwargs: Any) -> HTTPResponse:
-        if not hasattr(self, "_rate_limiter"):
-            self._rate_limiter = RateLimiter()
         await self._rate_limiter.acquire_async()
         return await self._client.get(url, **kwargs)
 
@@ -115,8 +109,6 @@ class HttpxAsyncClient(AsyncHTTPClient):
             The HTTP response instance returned by ``httpx``.
         """
 
-        if not hasattr(self, "_rate_limiter"):
-            self._rate_limiter = RateLimiter()
         await self._rate_limiter.acquire_async()
         if isinstance(data, (str | bytes)):
             return await self._client.post(url, content=data, **kwargs)

--- a/tests/integration/test_flow.py
+++ b/tests/integration/test_flow.py
@@ -1,7 +1,7 @@
 import httpx
 from conftest import make_user
 
-from pyskoob import SkoobClient
+from pyskoob import RateLimiter, SkoobClient
 from pyskoob.http.httpx import HttpxSyncClient
 
 
@@ -27,6 +27,7 @@ def test_login_and_search_flow(monkeypatch):
 
     def patched_init(self, **kwargs):
         self._client = httpx.Client(transport=transport)
+        self._rate_limiter = RateLimiter()
 
     monkeypatch.setattr(HttpxSyncClient, "__init__", patched_init, raising=False)
     monkeypatch.setattr(HttpxSyncClient, "close", lambda self: None, raising=False)

--- a/tests/test_httpx_rate_limiter.py
+++ b/tests/test_httpx_rate_limiter.py
@@ -1,0 +1,68 @@
+"""Tests for rate limiter behavior in HTTPX-based clients."""
+
+import httpx
+import pytest
+
+from pyskoob.http.httpx import HttpxAsyncClient, HttpxSyncClient
+
+
+@pytest.fixture
+def anyio_backend() -> str:
+    return "asyncio"
+
+
+class DummyLimiter:
+    """Simple limiter that counts acquire calls."""
+
+    def __init__(self) -> None:
+        self.calls = 0
+
+    def acquire(self) -> None:  # pragma: no cover - trivial increment
+        self.calls += 1
+
+    async def acquire_async(self) -> None:  # pragma: no cover - trivial increment
+        self.calls += 1
+
+
+def test_sync_client_reuses_existing_rate_limiter(monkeypatch: pytest.MonkeyPatch) -> None:
+    limiter = DummyLimiter()
+    client = HttpxSyncClient(rate_limiter=limiter)
+
+    def fake_get(self: httpx.Client, url: str, **kwargs: object) -> httpx.Response:
+        return httpx.Response(200)
+
+    def fake_post(self: httpx.Client, url: str, data: object | None = None, **kwargs: object) -> httpx.Response:
+        return httpx.Response(200)
+
+    monkeypatch.setattr(httpx.Client, "get", fake_get, raising=False)
+    monkeypatch.setattr(httpx.Client, "post", fake_post, raising=False)
+
+    client.get("https://example.com")
+    client.post("https://example.com")
+
+    assert client._rate_limiter is limiter
+    assert limiter.calls == 2
+    client.close()
+
+
+@pytest.mark.anyio
+async def test_async_client_reuses_existing_rate_limiter(monkeypatch: pytest.MonkeyPatch) -> None:
+    limiter = DummyLimiter()
+    client = HttpxAsyncClient(rate_limiter=limiter)
+
+    async def fake_get(self: httpx.AsyncClient, url: str, **kwargs: object) -> httpx.Response:
+        return httpx.Response(200)
+
+    async def fake_post(self: httpx.AsyncClient, url: str, data: object | None = None, **kwargs: object) -> httpx.Response:
+        return httpx.Response(200)
+
+    monkeypatch.setattr(httpx.AsyncClient, "get", fake_get, raising=False)
+    monkeypatch.setattr(httpx.AsyncClient, "post", fake_post, raising=False)
+
+    await client.get("https://example.com")
+    await client.post("https://example.com")
+
+    assert client._rate_limiter is limiter
+    assert limiter.calls == 2
+
+    await client.close()


### PR DESCRIPTION
## Summary
- remove repeated rate limiter checks in HTTPX clients
- add tests ensuring rate limiter reuse

## Testing
- `pre-commit run --all-files`
- `pytest -vv`


------
https://chatgpt.com/codex/tasks/task_e_6891e22541a88329a63f9abe7ded54f0