### PR TITLE
feat: add explicit close and custom client support

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,14 +114,21 @@ with SkoobClient(rate_limiter=limiter) as client:
 ```
 
 ``SkoobAsyncClient`` accepts the same configuration options and forwards any
-extra keyword arguments to ``httpx.AsyncClient``:
+extra keyword arguments to ``httpx.AsyncClient``. You may also provide a
+pre-configured HTTP client or manage the lifecycle manually using the explicit
+``close`` method:
 
 ```python
 from pyskoob import RateLimiter, SkoobAsyncClient
+from pyskoob.http.httpx import HttpxAsyncClient
 
 limiter = RateLimiter(max_calls=2, period=1)
-async with SkoobAsyncClient(rate_limiter=limiter, timeout=5) as client:
+http_client = HttpxAsyncClient(rate_limiter=limiter, timeout=5)
+client = SkoobAsyncClient(http_client=http_client)
+try:
     ...
+finally:
+    await client.close()
 ```
 
 ## Running tests

--- a/pyskoob/client.py
+++ b/pyskoob/client.py
@@ -5,6 +5,7 @@ from typing import Any
 from pyskoob.auth import AsyncAuthService, AuthService
 from pyskoob.authors import AsyncAuthorService, AuthorService
 from pyskoob.books import AsyncBookService, BookService
+from pyskoob.http.client import AsyncHTTPClient
 from pyskoob.http.httpx import HttpxAsyncClient, HttpxSyncClient
 from pyskoob.profile import AsyncSkoobProfileService, SkoobProfileService
 from pyskoob.publishers import AsyncPublisherService, PublisherService
@@ -88,15 +89,28 @@ class SkoobAsyncClient:
 
     Parameters
     ----------
+    http_client:
+        Optional pre-configured HTTP client implementing :class:`AsyncHTTPClient`.
+        When provided, ``rate_limiter`` and ``client_kwargs`` are ignored.
     rate_limiter:
-        Optional rate limiter used to throttle requests. If ``None``, a
-        default limiter allowing one request per second is used.
+        Optional rate limiter used to throttle requests. When ``http_client`` is
+        ``None``, a default limiter allowing one request per second is used.
     **client_kwargs:
-        Additional keyword arguments forwarded to ``httpx.AsyncClient``.
+        Additional keyword arguments forwarded to ``httpx.AsyncClient`` when the
+        default client is constructed.
     """
 
-    def __init__(self, rate_limiter: RateLimiter | None = None, **client_kwargs: Any) -> None:
-        self._client = HttpxAsyncClient(rate_limiter=rate_limiter, **client_kwargs)
+    def __init__(
+        self,
+        http_client: AsyncHTTPClient | None = None,
+        *,
+        rate_limiter: RateLimiter | None = None,
+        **client_kwargs: Any,
+    ) -> None:
+        if http_client is not None:
+            self._client = http_client
+        else:
+            self._client = HttpxAsyncClient(rate_limiter=rate_limiter, **client_kwargs)
         self.auth = AsyncAuthService(self._client)
         self.books = AsyncBookService(self._client)
         self.authors = AsyncAuthorService(self._client)
@@ -108,5 +122,15 @@ class SkoobAsyncClient:
         return self
 
     async def __aexit__(self, exc_type, exc_val, exc_tb) -> bool | None:
-        await self._client.close()
+        await self.close()
         return None
+
+    async def close(self) -> None:
+        """Close the underlying HTTP client.
+
+        Examples
+        --------
+        >>> client = SkoobAsyncClient()
+        >>> await client.close()
+        """
+        await self._client.close()

--- a/tests/test_skoob_async_client.py
+++ b/tests/test_skoob_async_client.py
@@ -1,3 +1,5 @@
+from typing import Any
+
 import httpx
 import pytest
 
@@ -31,3 +33,40 @@ async def test_async_client_allows_configuration(anyio_backend):
     async with SkoobAsyncClient(rate_limiter=limiter, timeout=5) as client:
         assert client._client._rate_limiter is limiter
         assert client._client._client.timeout == httpx.Timeout(5)
+
+
+async def test_async_client_close_method(monkeypatch, anyio_backend):
+    closed = False
+
+    async def fake_aclose(self):
+        nonlocal closed
+        closed = True
+
+    monkeypatch.setattr("httpx.AsyncClient.aclose", fake_aclose, raising=False)
+
+    client = SkoobAsyncClient()
+    await client.close()
+    assert closed
+
+
+class DummyAsyncClient:
+    def __init__(self) -> None:
+        self.closed = False
+        self.cookies: dict[str, Any] = {}
+
+    async def get(self, url: str, **kwargs: Any) -> Any:  # pragma: no cover - unused
+        raise NotImplementedError
+
+    async def post(self, url: str, data: Any | None = None, **kwargs: Any) -> Any:  # pragma: no cover - unused
+        raise NotImplementedError
+
+    async def close(self) -> None:
+        self.closed = True
+
+
+async def test_async_client_accepts_custom_http_client(anyio_backend):
+    dummy = DummyAsyncClient()
+    client = SkoobAsyncClient(http_client=dummy)
+    assert client._client is dummy
+    await client.close()
+    assert dummy.closed


### PR DESCRIPTION
## Summary
- add `close` method to `SkoobAsyncClient` for manual lifecycle management
- allow injecting a custom async HTTP client
- document manual client configuration and closing

## Testing
- `ruff format .`
- `ruff format --check .`
- `ruff check .`
- `pre-commit run --all-files`
- `pytest -vv`


------
https://chatgpt.com/codex/tasks/task_e_6891e22e88088329aaabe0d5db158c1b