### PR TITLE
Fix type hints and await checks in async profile service

### DIFF
--- a/pyskoob/parsers/authors.py
+++ b/pyskoob/parsers/authors.py
@@ -135,10 +135,10 @@ def extract_author_info(soup: Tag) -> tuple[str | None, str | None]:
     birth_date = None
     location = None
     if box_generos:
-        birth_b = box_generos.find("b", string=lambda s: s and "Nascimento" in s)
+        birth_b = box_generos.find("b", string=lambda s: bool(s) and "Nascimento" in s)
         if birth_b and birth_b.next_sibling:
             birth_date = str(birth_b.next_sibling).strip(" |")
-        loc_b = box_generos.find("b", string=lambda s: s and "Local" in s)
+        loc_b = box_generos.find("b", string=lambda s: bool(s) and "Local" in s)
         if loc_b and loc_b.next_sibling:
             loc_tag = loc_b.next_sibling
             location = get_tag_text(loc_tag) if isinstance(loc_tag, Tag) else str(loc_tag).strip()
@@ -172,7 +172,7 @@ def extract_author_stats(soup: Tag) -> AuthorStats:
         rating_span = safe_find(stats_div, "span", {"class": "rating"})
         rating_text = get_tag_text(rating_span).replace(",", ".")
         average_rating = float(rating_text) if rating_text else None
-        aval_span = stats_div.find("span", string=lambda t: t and "avalia" in t.lower())
+        aval_span = stats_div.find("span", string=lambda t: bool(t) and "avalia" in t.lower())
         if aval_span:
             aval_match = re.search(r"(\d+)", get_tag_text(aval_span).replace(".", ""))
             ratings = int(aval_match.group(1)) if aval_match else None

--- a/pyskoob/profile.py
+++ b/pyskoob/profile.py
@@ -225,7 +225,7 @@ class AsyncSkoobProfileService(AsyncAuthenticatedService):  # pragma: no cover -
             ``True`` if the operation succeeded.
         """
 
-        self._validate_login()
+        await self._validate_login()
         url = f"{self.base_url}/v1/label_add/{edition_id}/{label.value}"
         response = await self.client.get(url)
         response.raise_for_status()
@@ -245,7 +245,7 @@ class AsyncSkoobProfileService(AsyncAuthenticatedService):  # pragma: no cover -
             ``True`` if the operation succeeded.
         """
 
-        self._validate_login()
+        await self._validate_login()
         url = f"{self.base_url}/v1/label_del/{edition_id}"
         response = await self.client.get(url)
         response.raise_for_status()
@@ -267,7 +267,7 @@ class AsyncSkoobProfileService(AsyncAuthenticatedService):  # pragma: no cover -
             ``True`` if the status update succeeded.
         """
 
-        self._validate_login()
+        await self._validate_login()
         url = f"{self.base_url}/v1/shelf_add/{edition_id}/{status.value}"
         response = await self.client.get(url)
         response.raise_for_status()
@@ -287,7 +287,7 @@ class AsyncSkoobProfileService(AsyncAuthenticatedService):  # pragma: no cover -
             ``True`` if the status was removed successfully.
         """
 
-        self._validate_login()
+        await self._validate_login()
         url = f"{self.base_url}/v1/shelf_del/{edition_id}"
         response = await self.client.get(url)
         response.raise_for_status()
@@ -309,7 +309,7 @@ class AsyncSkoobProfileService(AsyncAuthenticatedService):  # pragma: no cover -
             ``True`` if the operation succeeded.
         """
 
-        self._validate_login()
+        await self._validate_login()
         url = f"{self.base_url}/estante/prateleira/{edition_id}/{bookshelf.value}"
         response = await self.client.get(url)
         response.raise_for_status()
@@ -338,7 +338,7 @@ class AsyncSkoobProfileService(AsyncAuthenticatedService):  # pragma: no cover -
             If Skoob rejects the rating.
         """
 
-        self._validate_login()
+        await self._validate_login()
         if not (0 <= ranking <= 5):
             raise ValueError("Rating must be between 0 and 5.")
         url = f"{self.base_url}/v1/book_rate/{edition_id}/{ranking}"

--- a/tests/test_httpx_rate_limiter.py
+++ b/tests/test_httpx_rate_limiter.py
@@ -4,6 +4,7 @@ import httpx
 import pytest
 
 from pyskoob.http.httpx import HttpxAsyncClient, HttpxSyncClient
+from pyskoob.utils import RateLimiter
 
 
 @pytest.fixture
@@ -11,10 +12,11 @@ def anyio_backend() -> str:
     return "asyncio"
 
 
-class DummyLimiter:
+class DummyLimiter(RateLimiter):
     """Simple limiter that counts acquire calls."""
 
     def __init__(self) -> None:
+        super().__init__()
         self.calls = 0
 
     def acquire(self) -> None:  # pragma: no cover - trivial increment

--- a/tests/test_skoob_async_client.py
+++ b/tests/test_skoob_async_client.py
@@ -1,9 +1,11 @@
-from typing import Any
+from collections.abc import MutableMapping
+from typing import Any, cast
 
 import httpx
 import pytest
 
 from pyskoob import RateLimiter, SkoobAsyncClient
+from pyskoob.http.httpx import HttpxAsyncClient
 
 pytestmark = pytest.mark.anyio
 
@@ -31,8 +33,9 @@ async def test_async_client_context_manager(monkeypatch, anyio_backend):
 async def test_async_client_allows_configuration(anyio_backend):
     limiter = RateLimiter()
     async with SkoobAsyncClient(rate_limiter=limiter, timeout=5) as client:
-        assert client._client._rate_limiter is limiter
-        assert client._client._client.timeout == httpx.Timeout(5)
+        http_client = cast(HttpxAsyncClient, client._client)
+        assert http_client._rate_limiter is limiter
+        assert http_client._client.timeout == httpx.Timeout(5)
 
 
 async def test_async_client_close_method(monkeypatch, anyio_backend):
@@ -52,7 +55,7 @@ async def test_async_client_close_method(monkeypatch, anyio_backend):
 class DummyAsyncClient:
     def __init__(self) -> None:
         self.closed = False
-        self.cookies: dict[str, Any] = {}
+        self.cookies: MutableMapping[str, Any] = {}
 
     async def get(self, url: str, **kwargs: Any) -> Any:  # pragma: no cover - unused
         raise NotImplementedError

--- a/tests/test_skoob_author_service.py
+++ b/tests/test_skoob_author_service.py
@@ -72,7 +72,8 @@ def test_get_by_id_parses_profile():
     assert profile.stats.star_ratings["5"] == 80.0
     assert profile.gender_percentages == {"male": 60.0, "female": 40.0}
     assert profile.birth_date == "01/01/2000"
-    assert profile.location.startswith("Brasil")
+    loc = profile.location
+    assert loc is not None and loc.startswith("Brasil")
     assert profile.tags == ["Fantasia"]
     assert profile.books[0].title == "B1"
     assert profile.videos[0].title == "V1"


### PR DESCRIPTION
## Summary
- ensure BeautifulSoup predicate lambdas return booleans
- await login validation in asynchronous profile service methods
- adjust tests for stricter typing and optional values

## Testing
- `pre-commit run --all-files`
- `pytest -vv`


------
https://chatgpt.com/codex/tasks/task_e_6891e944f1e08329a665bf60fa500758