### PR TITLE
Explicitly propagate exceptions in SkoobClient context manager

### DIFF
--- a/pyskoob/client.py
+++ b/pyskoob/client.py
@@ -58,9 +58,8 @@ class SkoobClient:
         """
         return self
 
-    def __exit__(self, exc_type, exc_val, exc_tb) -> bool | None:
-        """
-        Exit the runtime context, closing the HTTPX client.
+    def __exit__(self, exc_type, exc_val, exc_tb) -> bool:
+        """Exit the runtime context, closing the HTTPX client.
 
         Parameters
         ----------
@@ -73,17 +72,17 @@ class SkoobClient:
 
         Returns
         -------
-        bool or None
-            ``True`` to suppress the exception; otherwise ``None`` or ``False``
-            to propagate it.
+        bool
+            ``True`` to suppress the exception; ``False`` to propagate it.
 
         Examples
         --------
         >>> client = SkoobClient()
         >>> client.__exit__(None, None, None)
-        None
+        False
         """
         self._client.close()
+        return False
 
 
 class SkoobAsyncClient:


### PR DESCRIPTION
## Summary
- Make `SkoobClient.__exit__` explicitly return `False` so exceptions are never suppressed
- Update `SkoobClient.__exit__` docstring to show explicit return value

## Testing
- `ruff format --check .`
- `ruff check .`
- `pytest -vv`
- `pre-commit run --all-files`


------
https://chatgpt.com/codex/tasks/task_e_6891ff99e6348329b4b6996b01cde333

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified context manager behavior to specify that exceptions are either suppressed or propagated explicitly.

* **Refactor**
  * Enhanced consistency by ensuring the context manager method returns a strict boolean value, avoiding ambiguous cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->