### PR TITLE
refactor(users): use shared HTML parser

### DIFF
--- a/pyskoob/users.py
+++ b/pyskoob/users.py
@@ -4,8 +4,6 @@ import logging
 import re
 from datetime import datetime
 
-from bs4 import BeautifulSoup
-
 from pyskoob.auth import AsyncAuthService, AuthService
 from pyskoob.exceptions import ParsingError
 from pyskoob.http.client import AsyncHTTPClient, SyncHTTPClient
@@ -365,7 +363,7 @@ class UserService(AuthenticatedService):
         response = self.client.get(url)
         response.raise_for_status()
 
-        soup = BeautifulSoup(response.text, "html.parser")
+        soup = self.parse_html(response.text)
 
         try:
             user_divs = safe_find_all(
@@ -716,7 +714,7 @@ class AsyncUserService(AsyncAuthenticatedService):  # pragma: no cover - thin as
             url += f"/uf:{state.value}"
         response = await self.client.get(url)
         response.raise_for_status()
-        soup = BeautifulSoup(response.text, "html.parser")
+        soup = self.parse_html(response.text)
         try:
             user_divs = safe_find_all(
                 soup,


### PR DESCRIPTION
## Summary
- replace direct BeautifulSoup parsing with shared parse_html helper in synchronous and asynchronous user search
- remove unused BeautifulSoup import

## Testing
- `ruff format --check .`
- `ruff check .`
- `pytest -vv`


------
https://chatgpt.com/codex/tasks/task_e_6891ffa823408329bd5217d9648bb95c