### PR TITLE
feat: parse pagination totals for users

### DIFF
--- a/pyskoob/models/pagination.py
+++ b/pyskoob/models/pagination.py
@@ -14,8 +14,8 @@ class Pagination(BaseModel, Generic[T]):
     ----------
     results : list[T]
         Items returned for the current page.
-    total : int
-        Total number of items available.
+    total : int | None
+        Total number of items available, or ``None`` if the service does not provide it.
     page : int
         Current page index starting at ``1``.
     limit : int
@@ -25,7 +25,7 @@ class Pagination(BaseModel, Generic[T]):
     """
 
     results: list[T]
-    total: int
+    total: int | None = None
     page: int
     limit: int
     has_next_page: bool

--- a/pyskoob/users.py
+++ b/pyskoob/users.py
@@ -3,6 +3,7 @@
 import logging
 import re
 from datetime import datetime
+from typing import Any
 
 from bs4 import BeautifulSoup
 
@@ -33,6 +34,27 @@ from pyskoob.utils.skoob_parser_utils import (
 )
 
 logger = logging.getLogger(__name__)
+
+
+def _parse_total_from_html(soup: BeautifulSoup) -> int | None:
+    """Extract total count from common Skoob HTML counters."""
+
+    counter = safe_find(soup, "div", {"class": "contador"})
+    if counter:
+        match = re.search(r"\d+", get_tag_text(counter))
+        if match:
+            return int(match.group())
+    return None
+
+
+def _parse_total_from_paging(paging: dict[str, Any]) -> int | None:
+    """Extract total count from paging JSON metadata."""
+
+    for key in ("total", "total_items", "totalItems", "total_books", "totalBooks"):
+        value = paging.get(key)
+        if isinstance(value, int):
+            return value
+    return None
 
 
 class UserService(AuthenticatedService):
@@ -138,12 +160,13 @@ class UserService(AuthenticatedService):
             logger.error(f"Failed to parse user relations: {e}")
             raise ParsingError("Failed to parse user relations.") from e
 
+        total = _parse_total_from_html(soup)
         logger.info(f"Found {len(users_id)} users on page {page}.")
         return Pagination(
             results=users_id,
             limit=100,
             page=page,
-            total=len(users_id),  # Placeholder, actual total is not easily available
+            total=total,
             has_next_page=bool(next_page_link),
         )
 
@@ -216,12 +239,13 @@ class UserService(AuthenticatedService):
             logger.error(f"Failed to parse user reviews: {e}")
             raise ParsingError("Failed to parse user reviews.") from e
 
+        total = _parse_total_from_html(soup)
         logger.info(f"Found {len(user_reviews)} reviews on page {page}.")
         return Pagination(
             results=user_reviews,
             limit=50,
             page=page,
-            total=len(user_reviews),  # Placeholder, actual total is not easily available
+            total=total,
             has_next_page=bool(next_page_link),
         )
 
@@ -307,11 +331,12 @@ class UserService(AuthenticatedService):
                 )
             )
 
+        total = _parse_total_from_paging(json_data.get("paging", {}))
         logger.info(f"Found {len(results)} books on page {page}.")
         return Pagination(
             limit=100,
             results=results,
-            total=len(results),  # Placeholder, actual total is not easily available
+            total=total,
             has_next_page=bool(next_page),
             page=page,
         )
@@ -507,12 +532,14 @@ class AsyncUserService(AsyncAuthenticatedService):  # pragma: no cover - thin as
         except (AttributeError, ValueError, IndexError) as e:
             logger.error(f"Failed to parse user relations: {e}")
             raise ParsingError("Failed to parse user relations.") from e
+
+        total = _parse_total_from_html(soup)
         logger.info(f"Found {len(users_id)} users on page {page}.")
         return Pagination(
             results=users_id,
             limit=100,
             page=page,
-            total=len(users_id),
+            total=total,
             has_next_page=bool(next_page_link),
         )
 
@@ -582,12 +609,14 @@ class AsyncUserService(AsyncAuthenticatedService):  # pragma: no cover - thin as
         except (AttributeError, ValueError, IndexError) as e:
             logger.error(f"Failed to parse user reviews: {e}")
             raise ParsingError("Failed to parse user reviews.") from e
+
+        total = _parse_total_from_html(soup)
         logger.info(f"Found {len(user_reviews)} reviews on page {page}.")
         return Pagination(
             results=user_reviews,
             limit=50,
             page=page,
-            total=len(user_reviews),
+            total=total,
             has_next_page=bool(next_page_link),
         )
 
@@ -666,11 +695,12 @@ class AsyncUserService(AsyncAuthenticatedService):  # pragma: no cover - thin as
                     pages_read=r.get("paginas_lidas"),
                 )
             )
+        total = _parse_total_from_paging(json_data.get("paging", {}))
         logger.info(f"Found {len(results)} books on page {page}.")
         return Pagination(
             limit=100,
             results=results,
-            total=len(results),
+            total=total,
             has_next_page=bool(next_page),
             page=page,
         )

--- a/pyskoob/users.py
+++ b/pyskoob/users.py
@@ -1,5 +1,7 @@
 """Services for retrieving and manipulating Skoob user data."""
 
+from __future__ import annotations
+
 import logging
 import re
 from datetime import datetime

--- a/tests/test_skoob_user_service.py
+++ b/tests/test_skoob_user_service.py
@@ -76,11 +76,11 @@ def test_get_read_stats_and_bookcase():
                 "paginas_lidas": 0,
             }
         ],
-        "paging": {"next_page": None},
+        "paging": {"next_page": None, "total": 1},
     }
     client.json_data = bookcase_json
     books = service.get_bookcase(5, BookcaseOption.READ)
-    assert books.results[0].book_id == 1
+    assert books.results[0].book_id == 1 and books.total == 1
 
 
 def test_search_and_relations_and_reviews():
@@ -89,20 +89,21 @@ def test_search_and_relations_and_reviews():
     res = service.search("john")
     assert res.total == 1 and res.results[0].id == 10
 
-    relations_html = '<div class="usuarios-mini-lista-txt"><a href="/usuario/20-doe"></a></div>'
+    relations_html = '<div class="usuarios-mini-lista-txt"><a href="/usuario/20-doe"></a></div><div class="contador">1 amigos</div>'
     client.text = relations_html
     rel = service.get_relations(10, UsersRelation.FOLLOWERS)
-    assert rel.results == [20]
+    assert rel.results == [20] and rel.total == 1
 
     reviews_html = (
         "<div id='resenha1'><a href='/usuario/u'></a>"
         "<a href='/livro/1ed2.html'></a>"
         "<div id='resenhac1'><span>02/02/2020</span><p>Nice</p></div>"
         "<star-rating rate='5'/></div>"
+        "<div class='contador'>1 resenhas</div>"
     )
     client.text = reviews_html
     rev = service.get_reviews(10)
-    assert rev.results[0].rating == 5
+    assert rev.results[0].rating == 5 and rev.total == 1
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Summary
- parse total counts from Skoob HTML/JSON when available
- allow optional totals in Pagination model
- expand user service tests for pagination totals

## Testing
- `ruff format --check .`
- `ruff check .`
- `pytest -vv`


------
https://chatgpt.com/codex/tasks/task_e_6891ffb6244c83299000a053eaf9e0fe