### PR TITLE
feat: allow custom HTTP options for sync client

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,9 +113,10 @@ with SkoobClient(rate_limiter=limiter) as client:
     ...
 ```
 
-``SkoobAsyncClient`` accepts the same configuration options and forwards any
-extra keyword arguments to ``httpx.AsyncClient``. You may also provide a
-pre-configured HTTP client or manage the lifecycle manually using the explicit
+Both ``SkoobClient`` and ``SkoobAsyncClient`` accept the same configuration options
+and forward any extra keyword arguments to ``httpx.Client`` and
+``httpx.AsyncClient`` respectively. ``SkoobAsyncClient`` also allows providing a
+pre-configured HTTP client or managing the lifecycle manually using the explicit
 ``close`` method:
 
 ```python

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -15,6 +15,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) 
 - Pre-commit configuration for Ruff, formatting and tests.
 - Security policy describing vulnerability reporting and secret management.
 - Automated GitHub Pages workflow to build and deploy documentation.
+- ``SkoobClient`` now forwards additional keyword arguments to ``httpx.Client`` for
+  configuring timeouts, proxies and other options.
 ### Fixed
 - Avoided ``httpx`` deprecation warning when posting raw bytes or text.
 - Updated PyPI publish workflow to use the latest action release, resolving missing metadata errors.

--- a/pyskoob/client.py
+++ b/pyskoob/client.py
@@ -24,7 +24,7 @@ class SkoobClient:
     ...     client.auth.login_with_cookies("token")
     """
 
-    def __init__(self, rate_limiter: RateLimiter | None = None) -> None:
+    def __init__(self, rate_limiter: RateLimiter | None = None, **kwargs: Any) -> None:
         """Initializes the SkoobClient.
 
         Parameters
@@ -32,9 +32,12 @@ class SkoobClient:
         rate_limiter:
             Optional rate limiter used to throttle requests. If ``None``, a
             default limiter allowing one request per second is used.
+        **kwargs:
+            Additional keyword arguments forwarded to ``httpx.Client`` when the
+            underlying :class:`HttpxSyncClient` is constructed.
         """
 
-        self._client = HttpxSyncClient(rate_limiter=rate_limiter)
+        self._client = HttpxSyncClient(rate_limiter=rate_limiter, **kwargs)
         self.auth = AuthService(self._client)
         self.books = BookService(self._client)
         self.authors = AuthorService(self._client)

--- a/tests/test_skoob_client.py
+++ b/tests/test_skoob_client.py
@@ -1,4 +1,9 @@
-from pyskoob import SkoobClient
+from typing import cast
+
+import httpx
+
+from pyskoob import RateLimiter, SkoobClient
+from pyskoob.http.httpx import HttpxSyncClient
 
 
 def test_client_context_manager(monkeypatch):
@@ -14,3 +19,11 @@ def test_client_context_manager(monkeypatch):
         assert client.auth
         assert client.books
     assert closed
+
+
+def test_client_allows_configuration():
+    limiter = RateLimiter()
+    with SkoobClient(rate_limiter=limiter, timeout=5) as client:
+        http_client = cast(HttpxSyncClient, client._client)
+        assert http_client._rate_limiter is limiter
+        assert http_client._client.timeout == httpx.Timeout(5)


### PR DESCRIPTION
## Summary
- expose `kwargs` on `SkoobClient` and forward to `httpx.Client`
- document sync client's HTTP configuration support and changelog entry
- test that `SkoobClient` forwards kwargs to `HttpxSyncClient`

## Testing
- `ruff format --check .`
- `ruff check .`
- `pytest -vv`
- `pre-commit run --all-files`


------
https://chatgpt.com/codex/tasks/task_e_6891ff950f888329ad92bd32d7dfd515