### PR TITLE
feat: add HTTP retry with exponential backoff

### DIFF
--- a/pyskoob/__init__.py
+++ b/pyskoob/__init__.py
@@ -17,7 +17,7 @@ from .http.httpx import HttpxAsyncClient, HttpxSyncClient
 from .profile import AsyncSkoobProfileService, SkoobProfileService
 from .publishers import AsyncPublisherService, PublisherService
 from .users import AsyncUserService, UserService
-from .utils import RateLimiter
+from .utils import ExponentialBackoff, RateLimiter
 
 __all__ = [
     "AuthService",
@@ -39,5 +39,6 @@ __all__ = [
     "models",
     "ParsingError",
     "RateLimiter",
+    "ExponentialBackoff",
     "__version__",
 ]

--- a/pyskoob/utils/__init__.py
+++ b/pyskoob/utils/__init__.py
@@ -1,5 +1,6 @@
 """Utility helpers used throughout the project."""
 
+from .backoff import ExponentialBackoff
 from .rate_limiter import RateLimiter
 
-__all__ = ["RateLimiter"]
+__all__ = ["RateLimiter", "ExponentialBackoff"]

--- a/pyskoob/utils/backoff.py
+++ b/pyskoob/utils/backoff.py
@@ -1,0 +1,51 @@
+from __future__ import annotations
+
+"""Exponential backoff helpers."""
+
+import asyncio
+import time
+
+
+class ExponentialBackoff:
+    """Utility implementing exponential backoff delays.
+
+    Parameters
+    ----------
+    max_retries:
+        Number of retry attempts before giving up.
+    base_delay:
+        Initial delay in seconds for the first retry.
+    factor:
+        Multiplicative factor applied to the delay after each retry.
+    max_delay:
+        Upper bound for the calculated delay in seconds.
+    """
+
+    def __init__(
+        self,
+        max_retries: int = 3,
+        base_delay: float = 0.1,
+        factor: float = 2.0,
+        max_delay: float = 60.0,
+    ) -> None:
+        if max_retries < 0:
+            raise ValueError("max_retries must be non-negative")
+        self.max_retries = max_retries
+        self.base_delay = base_delay
+        self.factor = factor
+        self.max_delay = max_delay
+
+    def _compute_delay(self, attempt: int) -> float:
+        delay = self.base_delay * (self.factor**attempt)
+        return min(delay, self.max_delay)
+
+    def sleep(self, attempt: int) -> None:
+        """Sleep for the delay associated with ``attempt``."""
+        time.sleep(self._compute_delay(attempt))
+
+    async def sleep_async(self, attempt: int) -> None:
+        """Asynchronously sleep for the delay associated with ``attempt``."""
+        await asyncio.sleep(self._compute_delay(attempt))
+
+
+__all__ = ["ExponentialBackoff"]

--- a/tests/test_httpx_async_client.py
+++ b/tests/test_httpx_async_client.py
@@ -1,11 +1,13 @@
 import asyncio
 
 import httpx
+import pytest
 
 from pyskoob.http.httpx import HttpxAsyncClient
+from pyskoob.utils import ExponentialBackoff
 
 
-def test_async_client_get_post_aclose():
+def test_async_client_get_post_aclose() -> None:
     async def handler(request: httpx.Request) -> httpx.Response:
         if request.method == "GET":
             return httpx.Response(200, text="g")
@@ -20,6 +22,50 @@ def test_async_client_get_post_aclose():
         assert resp.text == "g"
         resp2 = await client.post("https://x", data="p")
         assert resp2.text == "p"
+        await client.close()
+
+    asyncio.run(main())
+
+
+def test_async_client_retries_on_http_error() -> None:
+    calls = {"count": 0}
+
+    async def handler(request: httpx.Request) -> httpx.Response:
+        calls["count"] += 1
+        if calls["count"] == 1:
+            raise httpx.TransportError("boom")
+        return httpx.Response(200, text="ok")
+
+    async def main() -> None:
+        transport = httpx.MockTransport(handler)
+        client = HttpxAsyncClient(
+            backoff=ExponentialBackoff(max_retries=1, base_delay=0),
+            transport=transport,
+        )
+        resp = await client.get("https://x")
+        assert resp.text == "ok"
+        assert calls["count"] == 2
+        await client.close()
+
+    asyncio.run(main())
+
+
+def test_async_client_raises_after_retries() -> None:
+    calls = {"count": 0}
+
+    async def handler(request: httpx.Request) -> httpx.Response:
+        calls["count"] += 1
+        raise httpx.TransportError("boom")
+
+    async def main() -> None:
+        transport = httpx.MockTransport(handler)
+        client = HttpxAsyncClient(
+            backoff=ExponentialBackoff(max_retries=1, base_delay=0),
+            transport=transport,
+        )
+        with pytest.raises(httpx.TransportError):
+            await client.get("https://x")
+        assert calls["count"] == 2
         await client.close()
 
     asyncio.run(main())

--- a/tests/test_httpx_sync_client.py
+++ b/tests/test_httpx_sync_client.py
@@ -1,0 +1,60 @@
+import httpx
+import pytest
+
+from pyskoob.http.httpx import HttpxSyncClient
+from pyskoob.utils import ExponentialBackoff
+
+
+def test_sync_client_get_post_close() -> None:
+    def handler(request: httpx.Request) -> httpx.Response:
+        if request.method == "GET":
+            return httpx.Response(200, text="g")
+        if request.method == "POST":
+            return httpx.Response(200, text=request.content.decode())
+        return httpx.Response(404)
+
+    transport = httpx.MockTransport(handler)
+    client = HttpxSyncClient(transport=transport)
+    resp = client.get("https://x")
+    assert resp.text == "g"
+    resp2 = client.post("https://x", data="p")
+    assert resp2.text == "p"
+    client.close()
+
+
+def test_sync_client_retries_on_http_error() -> None:
+    call_count = 0
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        nonlocal call_count
+        call_count += 1
+        if call_count == 1:
+            raise httpx.TransportError("boom")
+        return httpx.Response(200, text="ok")
+
+    transport = httpx.MockTransport(handler)
+    client = HttpxSyncClient(
+        backoff=ExponentialBackoff(max_retries=1, base_delay=0),
+        transport=transport,
+    )
+    resp = client.get("https://x")
+    assert resp.text == "ok"
+    assert call_count == 2
+
+
+def test_sync_client_raises_after_retries() -> None:
+    call_count = 0
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        nonlocal call_count
+        call_count += 1
+        raise httpx.TransportError("boom")
+
+    transport = httpx.MockTransport(handler)
+    client = HttpxSyncClient(
+        backoff=ExponentialBackoff(max_retries=1, base_delay=0),
+        transport=transport,
+    )
+    with pytest.raises(httpx.TransportError):
+        client.get("https://x")
+    assert call_count == 2


### PR DESCRIPTION
## Summary
- add `ExponentialBackoff` helper with sync/async sleep utilities
- integrate retries into httpx-based sync and async clients
- cover transient-error scenarios with unit tests

## Testing
- `ruff format --check .`
- `ruff check .`
- `pytest -vv`
- `pre-commit run --all-files`


------
https://chatgpt.com/codex/tasks/task_e_6891db5c95b48329a4875a0c63953e66

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced an exponential backoff mechanism for retrying failed HTTP requests, with configurable retry limits and delays.
  * Added support for both synchronous and asynchronous retry logic in HTTP clients.

* **Bug Fixes**
  * Improved HTTP client robustness by automatically retrying transient errors up to a specified limit.

* **Tests**
  * Added comprehensive tests to verify the retry behavior and error handling for both synchronous and asynchronous HTTP clients.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->