### PR TITLE
Refactor book service JSON parsing

### DIFF
--- a/pyskoob/books.py
+++ b/pyskoob/books.py
@@ -160,9 +160,10 @@ class BookService(BaseSkoobService):
             raise RequestError(f"Failed to retrieve book for edition_id {edition_id}.") from e
 
         try:
-            json_data = response.json().get("response")
+            data = response.json()
+            json_data = data.get("response")
             if not json_data:
-                cod_description = response.json().get("cod_description", "No description provided.")
+                cod_description = data.get("cod_description", "No description provided.")
                 error_msg = f"No data found for edition_id {edition_id}. Description: {cod_description}"
                 logger.warning(error_msg)
                 raise FileNotFoundError(error_msg)
@@ -406,9 +407,10 @@ class AsyncBookService(AsyncBaseSkoobService):  # pragma: no cover - thin async 
         try:
             response = await self.client.get(url)
             response.raise_for_status()
-            json_data = response.json().get("response")
+            data = response.json()
+            json_data = data.get("response")
             if not json_data:
-                cod_description = response.json().get("cod_description", "No description provided.")
+                cod_description = data.get("cod_description", "No description provided.")
                 error_msg = f"No data found for edition_id {edition_id}. Description: {cod_description}"
                 logger.warning(error_msg)
                 raise FileNotFoundError(error_msg)


### PR DESCRIPTION
## Summary
- parse book service responses once instead of twice
- apply same optimization to async variant

## Testing
- `pre-commit run --files pyskoob/books.py`
- `ruff format --check .`
- `ruff check .`
- `pytest -vv`


------
https://chatgpt.com/codex/tasks/task_e_68920bceed1c8329aeb6d774b9386e06