### PR TITLE
refactor: type hint async client __aexit__

### DIFF
--- a/pyskoob/client.py
+++ b/pyskoob/client.py
@@ -132,16 +132,21 @@ class SkoobAsyncClient:
     async def __aenter__(self) -> SkoobAsyncClient:
         return self
 
-    async def __aexit__(self, exc_type, exc_val, exc_tb) -> Literal[False]:
+    async def __aexit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc_val: BaseException | None,
+        exc_tb: TracebackType | None,
+    ) -> Literal[False]:
         """Exit the async runtime context, closing the HTTPX client.
 
         Parameters
         ----------
-        exc_type : type
+        exc_type : type[BaseException] | None
             The exception type.
-        exc_val : Exception
+        exc_val : BaseException | None
             The exception value.
-        exc_tb : traceback
+        exc_tb : TracebackType | None
             The traceback object.
 
         Returns


### PR DESCRIPTION
## Summary
- annotate SkoobAsyncClient.__aexit__ parameters for clarity and type safety

## Testing
- `ruff format .`
- `ruff format --check .`
- `ruff check .`
- `pre-commit run --all-files`
- `pytest -vv`


------
https://chatgpt.com/codex/tasks/task_e_68920bc41b5c8329804b83553b51d084