### PR TITLE
refactor: raise ProfileError when book rating fails

### DIFF
--- a/pyskoob/__init__.py
+++ b/pyskoob/__init__.py
@@ -12,7 +12,7 @@ from .auth import AsyncAuthService, AuthService
 from .authors import AsyncAuthorService, AuthorService
 from .books import AsyncBookService, BookService
 from .client import SkoobAsyncClient, SkoobClient
-from .exceptions import ParsingError, RequestError
+from .exceptions import ParsingError, ProfileError, RequestError
 from .http.httpx import HttpxAsyncClient, HttpxSyncClient
 from .profile import AsyncSkoobProfileService, SkoobProfileService
 from .publishers import AsyncPublisherService, PublisherService
@@ -38,6 +38,7 @@ __all__ = [
     "AsyncUserService",
     "models",
     "ParsingError",
+    "ProfileError",
     "RequestError",
     "RateLimiter",
     "__version__",

--- a/pyskoob/exceptions.py
+++ b/pyskoob/exceptions.py
@@ -11,3 +11,9 @@ class RequestError(Exception):
     """Custom exception for HTTP request failures."""
 
     pass
+
+
+class ProfileError(Exception):
+    """Custom exception for profile-related errors."""
+
+    pass

--- a/pyskoob/profile.py
+++ b/pyskoob/profile.py
@@ -3,6 +3,7 @@
 import logging
 
 from pyskoob.auth import AsyncAuthService, AuthService
+from pyskoob.exceptions import ProfileError
 from pyskoob.http.client import AsyncHTTPClient, SyncHTTPClient
 from pyskoob.internal.async_authenticated import AsyncAuthenticatedService
 from pyskoob.internal.authenticated import AuthenticatedService
@@ -182,8 +183,8 @@ class SkoobProfileService(AuthenticatedService):
         ------
         ValueError
             If the rating is not between 0 and 5.
-        RuntimeError
-            If it fails to rate the book.
+        ProfileError
+            If Skoob rejects the rating.
 
         Examples
         --------
@@ -199,7 +200,7 @@ class SkoobProfileService(AuthenticatedService):
         response.raise_for_status()
 
         if not response.json().get("success"):
-            raise RuntimeError("Failed to rate the book.")
+            raise ProfileError("Failed to rate the book.")
         return True
 
 
@@ -334,7 +335,7 @@ class AsyncSkoobProfileService(AsyncAuthenticatedService):  # pragma: no cover -
         ------
         ValueError
             If ``ranking`` is outside the 0–5 range.
-        RuntimeError
+        ProfileError
             If Skoob rejects the rating.
         """
 
@@ -345,5 +346,5 @@ class AsyncSkoobProfileService(AsyncAuthenticatedService):  # pragma: no cover -
         response = await self.client.get(url)
         response.raise_for_status()
         if not response.json().get("success"):
-            raise RuntimeError("Failed to rate the book.")
+            raise ProfileError("Failed to rate the book.")
         return True

--- a/tests/test_profile_service.py
+++ b/tests/test_profile_service.py
@@ -3,6 +3,7 @@ from typing import cast
 import pytest
 
 from pyskoob.auth import AuthService
+from pyskoob.exceptions import ProfileError
 from pyskoob.http.client import SyncHTTPClient
 from pyskoob.models.enums import BookLabel, BookShelf, BookStatus
 from pyskoob.profile import SkoobProfileService
@@ -56,7 +57,7 @@ def test_rate_book_invalid_range():
 
 def test_rate_book_failure():
     service, _ = make_service(False)
-    with pytest.raises(RuntimeError):
+    with pytest.raises(ProfileError):
         service.rate_book(1, 3)
 
 


### PR DESCRIPTION
## Summary
- add `ProfileError` to represent profile-related failures
- raise `ProfileError` when Skoob rejects book rating
- export `ProfileError` and update related tests

## Testing
- `ruff format .`
- `ruff format --check .`
- `ruff check .`
- `pre-commit run --all-files`
- `pytest -vv`


------
https://chatgpt.com/codex/tasks/task_e_68920bad405c83299b46ce13b0d0919c