### PR TITLE
Refactor rate limiter to release locks while sleeping

### DIFF
--- a/pyskoob/utils/rate_limiter.py
+++ b/pyskoob/utils/rate_limiter.py
@@ -45,24 +45,24 @@ class RateLimiter:
         configured rate limit is always honoured even if the thread wakes up
         earlier than expected.
         """
-        with self._lock:
-            while True:
+        while True:
+            with self._lock:
                 now = time.monotonic()
                 self._trim(now)
                 if len(self._calls) < self._max_calls:
                     self._calls.append(now)
                     return
                 sleep_for = self._period - (now - self._calls[0])
-                time.sleep(sleep_for)
+            time.sleep(sleep_for)
 
     async def acquire_async(self) -> None:
         """Asynchronous variant of :meth:`acquire` with the same guarantees."""
-        async with self._async_lock:
-            while True:
+        while True:
+            async with self._async_lock:
                 now = time.monotonic()
                 self._trim(now)
                 if len(self._calls) < self._max_calls:
                     self._calls.append(now)
                     return
                 sleep_for = self._period - (now - self._calls[0])
-                await asyncio.sleep(sleep_for)
+            await asyncio.sleep(sleep_for)


### PR DESCRIPTION
## Summary
- release internal locks before sleeping in `RateLimiter`
- add tests ensuring synchronous and asynchronous locks are free during wait periods

## Testing
- `pre-commit run --all-files`
- `pytest -vv`


------
https://chatgpt.com/codex/tasks/task_e_68920bdf911c8329a8328c7e606f14ee