### PR TITLE
ci: add security scanning

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,6 +52,37 @@ jobs:
       - name: Type check with mypy
         run: mypy pyskoob
 
+  security:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Set up uv
+        uses: astral-sh/setup-uv@v6
+
+      - name: Cache dependencies
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/uv
+          key: ${{ runner.os }}-uv-${{ hashFiles('uv.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-uv-
+
+      - name: Install security tools
+        run: uv pip install --system "bandit==1.7.8" "pip-audit==2.7.3"
+
+      - name: Run bandit
+        run: bandit -r pyskoob -x tests
+
+      - name: Run pip-audit
+        run: pip-audit
+
   test:
     # Run tests on ubuntu runners for each supported Python version
     permissions:


### PR DESCRIPTION
## Summary
- add a security scanning job to the CI workflow using Bandit and pip-audit

## Testing
- `pre-commit run --files .github/workflows/ci.yml`
- `ruff format --check .`
- `ruff check .`
- `pytest -vv`


------
https://chatgpt.com/codex/tasks/task_e_68920b8b89148329b286a66a05916743