### PR TITLE
Add concurrent tests for RateLimiter

### DIFF
--- a/tests/test_rate_limiter.py
+++ b/tests/test_rate_limiter.py
@@ -1,5 +1,6 @@
 import asyncio
 import time
+from threading import Barrier, Thread
 
 from pyskoob.utils import RateLimiter
 
@@ -24,6 +25,50 @@ def test_rate_limiter_blocks_asynchronously() -> None:
 
     elapsed = asyncio.run(run())
     assert elapsed >= 0.05
+
+
+def test_rate_limiter_is_thread_safe() -> None:
+    limiter = RateLimiter(max_calls=2, period=0.05)
+    barrier = Barrier(4)
+    times: list[float] = []
+
+    def worker() -> None:
+        barrier.wait()
+        limiter.acquire()
+        times.append(time.monotonic())
+
+    threads = [Thread(target=worker) for _ in range(3)]
+    for thread in threads:
+        thread.start()
+    start = time.monotonic()
+    barrier.wait()
+    for thread in threads:
+        thread.join()
+
+    results = sorted(t - start for t in times)
+    assert results[2] - results[0] >= 0.05
+
+
+def test_rate_limiter_is_async_thread_safe() -> None:
+    limiter = RateLimiter(max_calls=2, period=0.05)
+
+    async def run() -> list[float]:
+        start_event = asyncio.Event()
+        times: list[float] = []
+
+        async def worker() -> None:
+            await start_event.wait()
+            await limiter.acquire_async()
+            times.append(time.monotonic())
+
+        tasks = [asyncio.create_task(worker()) for _ in range(3)]
+        start = time.monotonic()
+        start_event.set()
+        await asyncio.gather(*tasks)
+        return sorted(t - start for t in times)
+
+    results = asyncio.run(run())
+    assert results[2] - results[0] >= 0.05
 
 
 def test_rate_limiter_default_is_one_per_second() -> None:


### PR DESCRIPTION
## Summary
- expand RateLimiter test coverage with concurrent thread and asyncio tests
- verify limiter serialization across threads and tasks

## Testing
- `ruff format --check tests/test_rate_limiter.py`
- `ruff check tests/test_rate_limiter.py`
- `pre-commit run --files tests/test_rate_limiter.py`
- `pytest -vv`


------
https://chatgpt.com/codex/tasks/task_e_68920b874d848329b48bc4b7a83843d3