### PR TITLE
feat: add SkoobClient.close for manual lifecycle management

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,9 +115,20 @@ with SkoobClient(rate_limiter=limiter) as client:
 
 Both ``SkoobClient`` and ``SkoobAsyncClient`` accept the same configuration options
 and forward any extra keyword arguments to ``httpx.Client`` and
-``httpx.AsyncClient`` respectively. ``SkoobAsyncClient`` also allows providing a
-pre-configured HTTP client or managing the lifecycle manually using the explicit
-``close`` method:
+``httpx.AsyncClient`` respectively. They also expose a ``close`` method for
+manual lifecycle management outside a context manager:
+
+```python
+from pyskoob import SkoobClient
+
+client = SkoobClient(timeout=5)
+try:
+    ...
+finally:
+    client.close()
+```
+
+``SkoobAsyncClient`` additionally allows providing a pre-configured HTTP client:
 
 ```python
 from pyskoob import RateLimiter, SkoobAsyncClient

--- a/pyskoob/client.py
+++ b/pyskoob/client.py
@@ -91,8 +91,18 @@ class SkoobClient:
         >>> client.__exit__(None, None, None)
         False
         """
-        self._client.close()
+        self.close()
         return False
+
+    def close(self) -> None:
+        """Close the underlying HTTP client.
+
+        Examples
+        --------
+        >>> client = SkoobClient()
+        >>> client.close()
+        """
+        self._client.close()
 
 
 class SkoobAsyncClient:

--- a/tests/test_skoob_client.py
+++ b/tests/test_skoob_client.py
@@ -21,6 +21,20 @@ def test_client_context_manager(monkeypatch):
     assert closed
 
 
+def test_client_explicit_close(monkeypatch):
+    closed = False
+
+    def fake_close(self):
+        nonlocal closed
+        closed = True
+
+    monkeypatch.setattr("httpx.Client.close", fake_close, raising=False)
+
+    client = SkoobClient()
+    client.close()
+    assert closed
+
+
 def test_client_allows_configuration():
     limiter = RateLimiter()
     with SkoobClient(rate_limiter=limiter, timeout=5) as client:


### PR DESCRIPTION
## Summary
- add SkoobClient.close to mirror async client API
- document manual closing for sync client
- test SkoobClient.close behavior

## Testing
- `ruff format .`
- `ruff format --check .`
- `ruff check .`
- `pre-commit run --all-files`
- `pytest -vv`


------
https://chatgpt.com/codex/tasks/task_e_68920bbed2ac8329b9f792c1a2cefe16