### PR TITLE
feat: add HTTP retry with exponential backoff

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,6 +113,21 @@ with SkoobClient(rate_limiter=limiter) as client:
     ...
 ```
 
+## Network retries
+
+PySkoob automatically retries requests that fail due to transient network
+errors using an exponential backoff strategy. The default policy retries up to
+three times. Customise this behaviour by supplying a
+``pyskoob.utils.Retry`` instance:
+
+```python
+from pyskoob import Retry, SkoobClient
+
+retry = Retry(max_attempts=5, base_delay=0.1)
+with SkoobClient(retry=retry) as client:
+    ...
+```
+
 Both ``SkoobClient`` and ``SkoobAsyncClient`` accept the same configuration options
 and forward any extra keyword arguments to ``httpx.Client`` and
 ``httpx.AsyncClient`` respectively. They also expose a ``close`` method for

--- a/pyskoob/__init__.py
+++ b/pyskoob/__init__.py
@@ -17,7 +17,7 @@ from .http.httpx import HttpxAsyncClient, HttpxSyncClient
 from .profile import AsyncSkoobProfileService, SkoobProfileService
 from .publishers import AsyncPublisherService, PublisherService
 from .users import AsyncUserService, UserService
-from .utils import RateLimiter
+from .utils import RateLimiter, Retry
 
 __all__ = [
     "AuthService",
@@ -41,5 +41,6 @@ __all__ = [
     "ProfileError",
     "RequestError",
     "RateLimiter",
+    "Retry",
     "__version__",
 ]

--- a/pyskoob/client.py
+++ b/pyskoob/client.py
@@ -13,7 +13,7 @@ from pyskoob.http.httpx import HttpxAsyncClient, HttpxSyncClient
 from pyskoob.profile import AsyncSkoobProfileService, SkoobProfileService
 from pyskoob.publishers import AsyncPublisherService, PublisherService
 from pyskoob.users import AsyncUserService, UserService
-from pyskoob.utils import RateLimiter
+from pyskoob.utils import RateLimiter, Retry
 
 
 class SkoobClient:
@@ -25,7 +25,12 @@ class SkoobClient:
     ...     client.auth.login_with_cookies("token")
     """
 
-    def __init__(self, rate_limiter: RateLimiter | None = None, **kwargs: Any) -> None:
+    def __init__(
+        self,
+        rate_limiter: RateLimiter | None = None,
+        retry: Retry | None = None,
+        **kwargs: Any,
+    ) -> None:
         """Initializes the SkoobClient.
 
         Parameters
@@ -33,12 +38,15 @@ class SkoobClient:
         rate_limiter:
             Optional rate limiter used to throttle requests. If ``None``, a
             default limiter allowing one request per second is used.
+        retry:
+            Optional retry handler for automatically retrying requests on
+            network errors. If ``None`` a default configuration is used.
         **kwargs:
             Additional keyword arguments forwarded to ``httpx.Client`` when the
             underlying :class:`HttpxSyncClient` is constructed.
         """
 
-        self._client = HttpxSyncClient(rate_limiter=rate_limiter, **kwargs)
+        self._client = HttpxSyncClient(rate_limiter=rate_limiter, retry=retry, **kwargs)
         self.auth = AuthService(self._client)
         self.books = BookService(self._client)
         self.authors = AuthorService(self._client)
@@ -116,6 +124,9 @@ class SkoobAsyncClient:
     rate_limiter:
         Optional rate limiter used to throttle requests. When ``http_client`` is
         ``None``, a default limiter allowing one request per second is used.
+    retry:
+        Optional retry handler for automatically retrying requests on network
+        errors. Ignored when ``http_client`` is provided.
     **client_kwargs:
         Additional keyword arguments forwarded to ``httpx.AsyncClient`` when the
         default client is constructed.
@@ -126,12 +137,13 @@ class SkoobAsyncClient:
         http_client: AsyncHTTPClient | None = None,
         *,
         rate_limiter: RateLimiter | None = None,
+        retry: Retry | None = None,
         **client_kwargs: Any,
     ) -> None:
         if http_client is not None:
             self._client = http_client
         else:
-            self._client = HttpxAsyncClient(rate_limiter=rate_limiter, **client_kwargs)
+            self._client = HttpxAsyncClient(rate_limiter=rate_limiter, retry=retry, **client_kwargs)
         self.auth = AsyncAuthService(self._client)
         self.books = AsyncBookService(self._client)
         self.authors = AsyncAuthorService(self._client)

--- a/pyskoob/utils/__init__.py
+++ b/pyskoob/utils/__init__.py
@@ -1,5 +1,6 @@
 """Utility helpers used throughout the project."""
 
 from .rate_limiter import RateLimiter
+from .retry import Retry
 
-__all__ = ["RateLimiter"]
+__all__ = ["RateLimiter", "Retry"]

--- a/pyskoob/utils/retry.py
+++ b/pyskoob/utils/retry.py
@@ -1,0 +1,78 @@
+from __future__ import annotations
+
+"""Utilities for retrying operations with exponential backoff."""
+
+import asyncio
+import time
+from collections.abc import Awaitable, Callable, Iterable
+from typing import Any
+
+
+class Retry:
+    """Retry a callable with exponential backoff on specified exceptions.
+
+    Parameters
+    ----------
+    max_attempts:
+        Maximum number of attempts before giving up. Defaults to ``3``.
+    base_delay:
+        Initial delay in seconds used for the exponential backoff calculation.
+        The delay for each retry is ``base_delay * 2**(attempt - 1)`` where
+        ``attempt`` starts at ``1`` for the first retry. Defaults to ``0.5``.
+    exceptions:
+        Iterable of exception types that should trigger a retry. By default all
+        exceptions are retried.
+    """
+
+    def __init__(
+        self,
+        max_attempts: int = 3,
+        base_delay: float = 0.5,
+        exceptions: Iterable[type[Exception]] | None = None,
+    ) -> None:
+        self._max_attempts = max_attempts
+        self._base_delay = base_delay
+        self._exceptions = tuple(exceptions or (Exception,))
+
+    def _sleep(self, attempt: int) -> None:
+        delay = self._base_delay * (2 ** (attempt - 1))
+        if delay > 0:
+            time.sleep(delay)
+
+    async def _sleep_async(self, attempt: int) -> None:
+        delay = self._base_delay * (2 ** (attempt - 1))
+        if delay > 0:
+            await asyncio.sleep(delay)
+
+    def run(self, func: Callable[..., Any], *args: Any, **kwargs: Any) -> Any:
+        """Execute ``func`` with retries on failure.
+
+        The function is called immediately. If it raises one of the configured
+        exceptions the call is retried using exponential backoff.
+        """
+        attempt = 0
+        while True:
+            try:
+                return func(*args, **kwargs)
+            except self._exceptions:
+                attempt += 1
+                if attempt >= self._max_attempts:
+                    raise
+                self._sleep(attempt)
+
+    async def run_async(
+        self,
+        func: Callable[..., Awaitable[Any]],
+        *args: Any,
+        **kwargs: Any,
+    ) -> Any:
+        """Asynchronous variant of :meth:`run`."""
+        attempt = 0
+        while True:
+            try:
+                return await func(*args, **kwargs)
+            except self._exceptions:
+                attempt += 1
+                if attempt >= self._max_attempts:
+                    raise
+                await self._sleep_async(attempt)

--- a/tests/integration/test_flow.py
+++ b/tests/integration/test_flow.py
@@ -1,7 +1,7 @@
 import httpx
 from conftest import make_user
 
-from pyskoob import RateLimiter, SkoobClient
+from pyskoob import RateLimiter, Retry, SkoobClient
 from pyskoob.http.httpx import HttpxSyncClient
 
 
@@ -28,6 +28,7 @@ def test_login_and_search_flow(monkeypatch):
     def patched_init(self, **kwargs):
         self._client = httpx.Client(transport=transport)
         self._rate_limiter = RateLimiter()
+        self._retry = Retry()
 
     monkeypatch.setattr(HttpxSyncClient, "__init__", patched_init, raising=False)
     monkeypatch.setattr(HttpxSyncClient, "close", lambda self: None, raising=False)

--- a/tests/test_httpx_retry.py
+++ b/tests/test_httpx_retry.py
@@ -1,0 +1,69 @@
+"""Tests for retry behaviour in HTTPX-based clients."""
+
+import httpx
+import pytest
+
+from pyskoob.http.httpx import HttpxAsyncClient, HttpxSyncClient
+from pyskoob.utils import RateLimiter, Retry
+
+
+@pytest.fixture
+def anyio_backend() -> str:
+    return "asyncio"
+
+
+class DummyLimiter(RateLimiter):
+    """Limiter that never blocks."""
+
+    def acquire(self) -> None:  # pragma: no cover - trivial
+        return
+
+    async def acquire_async(self) -> None:  # pragma: no cover - trivial
+        return
+
+
+def test_sync_client_retries_on_transport_error(monkeypatch: pytest.MonkeyPatch) -> None:
+    attempts = 0
+
+    def fake_get(self: httpx.Client, url: str, **kwargs: object) -> httpx.Response:
+        nonlocal attempts
+        attempts += 1
+        if attempts < 3:
+            raise httpx.TransportError("boom")
+        return httpx.Response(200)
+
+    monkeypatch.setattr(httpx.Client, "get", fake_get, raising=False)
+
+    retry = Retry(max_attempts=3, base_delay=0, exceptions=(httpx.TransportError,))
+    client = HttpxSyncClient(rate_limiter=DummyLimiter(), retry=retry)
+
+    response = client.get("https://example.com")
+
+    assert attempts == 3
+    assert response.status_code == 200
+
+    client.close()
+
+
+@pytest.mark.anyio
+async def test_async_client_retries_on_transport_error(monkeypatch: pytest.MonkeyPatch) -> None:
+    attempts = 0
+
+    async def fake_get(self: httpx.AsyncClient, url: str, **kwargs: object) -> httpx.Response:
+        nonlocal attempts
+        attempts += 1
+        if attempts < 3:
+            raise httpx.TransportError("boom")
+        return httpx.Response(200)
+
+    monkeypatch.setattr(httpx.AsyncClient, "get", fake_get, raising=False)
+
+    retry = Retry(max_attempts=3, base_delay=0, exceptions=(httpx.TransportError,))
+    client = HttpxAsyncClient(rate_limiter=DummyLimiter(), retry=retry)
+
+    response = await client.get("https://example.com")
+
+    assert attempts == 3
+    assert response.status_code == 200
+
+    await client.close()

--- a/tests/test_skoob_async_client.py
+++ b/tests/test_skoob_async_client.py
@@ -4,7 +4,7 @@ from typing import Any, cast
 import httpx
 import pytest
 
-from pyskoob import RateLimiter, SkoobAsyncClient
+from pyskoob import RateLimiter, Retry, SkoobAsyncClient
 from pyskoob.http.httpx import HttpxAsyncClient
 
 pytestmark = pytest.mark.anyio
@@ -32,9 +32,11 @@ async def test_async_client_context_manager(monkeypatch, anyio_backend):
 
 async def test_async_client_allows_configuration(anyio_backend):
     limiter = RateLimiter()
-    async with SkoobAsyncClient(rate_limiter=limiter, timeout=5) as client:
+    retry = Retry(max_attempts=1)
+    async with SkoobAsyncClient(rate_limiter=limiter, retry=retry, timeout=5) as client:
         http_client = cast(HttpxAsyncClient, client._client)
         assert http_client._rate_limiter is limiter
+        assert http_client._retry is retry
         assert http_client._client.timeout == httpx.Timeout(5)
 
 

--- a/tests/test_skoob_client.py
+++ b/tests/test_skoob_client.py
@@ -2,7 +2,7 @@ from typing import cast
 
 import httpx
 
-from pyskoob import RateLimiter, SkoobClient
+from pyskoob import RateLimiter, Retry, SkoobClient
 from pyskoob.http.httpx import HttpxSyncClient
 
 
@@ -37,7 +37,9 @@ def test_client_explicit_close(monkeypatch):
 
 def test_client_allows_configuration():
     limiter = RateLimiter()
-    with SkoobClient(rate_limiter=limiter, timeout=5) as client:
+    retry = Retry(max_attempts=1)
+    with SkoobClient(rate_limiter=limiter, retry=retry, timeout=5) as client:
         http_client = cast(HttpxSyncClient, client._client)
         assert http_client._rate_limiter is limiter
+        assert http_client._retry is retry
         assert http_client._client.timeout == httpx.Timeout(5)


### PR DESCRIPTION
## Summary
- add configurable Retry utility with exponential backoff
- integrate retry into HTTP clients and expose through SkoobClient APIs
- document network retry support and add regression tests

## Testing
- `pre-commit run --all-files`
- `pytest -vv`


------
https://chatgpt.com/codex/tasks/task_e_6892163f4dbc832993cefbbf30be32a0