### PR TITLE
bugfix: fix HTTPX retry test typing

### DIFF
--- a/tests/test_httpx_retry.py
+++ b/tests/test_httpx_retry.py
@@ -1,7 +1,5 @@
 """Tests for retry behaviour in HTTPX-based clients."""
 
-from typing import cast
-
 import httpx
 import pytest
 
@@ -39,7 +37,7 @@ def test_sync_client_retries_on_transport_error(monkeypatch: pytest.MonkeyPatch)
     retry = Retry(max_attempts=3, base_delay=0, exceptions=(httpx.TransportError,))
     client = HttpxSyncClient(rate_limiter=DummyLimiter(), retry=retry)
 
-    response = cast(httpx.Response, client.get("https://example.com"))
+    response: httpx.Response = client.get("https://example.com")
 
     assert attempts == 3
     assert response.status_code == 200
@@ -63,7 +61,7 @@ async def test_async_client_retries_on_transport_error(monkeypatch: pytest.Monke
     retry = Retry(max_attempts=3, base_delay=0, exceptions=(httpx.TransportError,))
     client = HttpxAsyncClient(rate_limiter=DummyLimiter(), retry=retry)
 
-    response = cast(httpx.Response, await client.get("https://example.com"))
+    response: httpx.Response = await client.get("https://example.com")
 
     assert attempts == 3
     assert response.status_code == 200


### PR DESCRIPTION
## Summary
- cast HTTPX retry responses to httpx.Response so tests can check status codes

## Testing
- `ruff format --check .`
- `ruff check .`
- `pytest -vv`
- `pre-commit run --all-files`


------
https://chatgpt.com/codex/tasks/task_e_68921cef29a48329931a610224a97b29

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved type clarity in test cases to ensure better code readability and maintainability. No changes to test logic or outcomes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->