### PR TITLE
refactor: unify sync and async services

### DIFF
--- a/pyskoob/auth.py
+++ b/pyskoob/auth.py
@@ -1,103 +1,36 @@
 """Authentication helpers and session management for Skoob."""
 
+from __future__ import annotations
+
 import logging
+from typing import Any
 
 from pyskoob.http.client import AsyncHTTPClient, SyncHTTPClient
 from pyskoob.internal.async_base import AsyncBaseSkoobService
 from pyskoob.internal.base import BaseSkoobService
 from pyskoob.models.user import User
+from pyskoob.utils.sync_async import maybe_await, run_sync
 
 logger = logging.getLogger(__name__)
 
 
-class AuthService(BaseSkoobService):
-    """Handle authentication with Skoob and track login state.
+class _AuthServiceMixin:
+    """Shared authentication logic for sync and async services."""
 
-    The service exposes login helpers and validates whether requests are
-    performed as an authenticated user. Other high-level services depend on
-    this class to ensure session-sensitive operations are authorized.
-    """
+    client: Any
+    base_url: str
 
-    def __init__(self, client: SyncHTTPClient):
-        """Manage Skoob authentication and session validation.
+    _is_logged_in: bool
 
-        The service wraps the login workflow and stores the session state so
-        other services (such as :class:`UserService` or
-        :class:`SkoobProfileService`) can verify that requests are
-        authenticated before accessing user data.
-
-        Parameters
-        ----------
-        client : SyncHTTPClient
-            The HTTP client to use for requests.
-
-        Examples
-        --------
-        >>> import httpx
-        >>> service = AuthService(httpx.Client())
-        """
-        super().__init__(client)
-        self._is_logged_in = False
-
-    def login_with_cookies(self, session_token: str) -> User:
-        """
-        Logs in the user using a session token.
-
-        Parameters
-        ----------
-        session_token : str
-            The PHPSESSID token from Skoob.
-
-        Returns
-        -------
-        User
-            The authenticated user's information.
-
-        Raises
-        ------
-        ConnectionError
-            If retrieving user information fails.
-        PermissionError
-            If the provided session token is invalid or expired.
-
-        Examples
-        --------
-        >>> service.login_with_cookies("PHPSESSID=abc123")
-        User(name='example')
-        """
+    async def _login_with_cookies(self, session_token: str) -> User:
         logger.info("Attempting to log in with session token.")
         self.client.cookies.update({"PHPSESSID": session_token})
-        user = self.get_my_info()
+        user = await self._get_my_info()
         self._is_logged_in = True
         logger.info("Successfully logged in as user: '%s'", user.name)
         return user
 
-    def login(self, email: str, password: str) -> User:
-        """
-        Logs in the user using email and password.
-
-        Parameters
-        ----------
-        email : str
-            The user's email address.
-        password : str
-            The user's password.
-
-        Returns
-        -------
-        User
-            The authenticated user's information.
-
-        Raises
-        ------
-        ConnectionError
-            If authentication fails or the session cannot be established.
-
-        Examples
-        --------
-        >>> service.login("user@example.com", "password")
-        User(name='example')
-        """
+    async def _login(self, email: str, password: str) -> User:
         logger.info("Attempting to log in with email and password.")
         url = f"{self.base_url}/v1/login"
         data = {
@@ -105,132 +38,7 @@ class AuthService(BaseSkoobService):
             "data[Usuario][senha]": password,
             "data[Login][automatico]": True,
         }
-
-        response = self.client.post(url, data=data)
-        response.raise_for_status()
-
-        try:
-            json_data = response.json()
-        except ValueError as exc:
-            logger.error("Login response was not valid JSON")
-            raise ConnectionError("Invalid response format") from exc
-        if not json_data.get("success", False):
-            logger.error("Login failed: %s", json_data.get("message", "Unknown error"))
-            raise ConnectionError("Failed to login: {}".format(json_data.get("message", "Unknown error")))
-
-        self._is_logged_in = True
-        user = self.get_my_info()
-        logger.info("Successfully logged in as user: '%s'", user.name)
-        return user
-
-    def get_my_info(self) -> User:
-        """
-        Retrieves the authenticated user's information.
-
-        Returns
-        -------
-        User
-            The authenticated user's information.
-
-        Raises
-        ------
-        ConnectionError
-            If it fails to retrieve user information.
-
-        Examples
-        --------
-        >>> service.get_my_info().name
-        'Example User'
-        """
-        logger.info("Getting authenticated user's information.")
-        url = f"{self.base_url}/v1/user/stats:true"
-        response = self.client.get(url)
-        response.raise_for_status()
-
-        json_data = response.json()
-        if not json_data.get("success"):
-            logger.error("Failed to retrieve user information. The session token might be invalid.")
-            raise ConnectionError("Failed to retrieve user information. The session token might be invalid.")
-
-        user_data = json_data["response"]
-        user_data["profile_url"] = self.base_url + user_data["url"]  # patch field for alias
-        user = User.model_validate(user_data)
-        logger.info("Successfully retrieved user: '%s'", user.name)
-        return user
-
-    def validate_login(self) -> None:
-        """
-        Validates if the user is logged in.
-
-        Raises
-        ------
-        PermissionError
-            If the user is not logged in.
-
-        Examples
-        --------
-        >>> service.validate_login()
-        None
-        """
-        logger.debug("Validating login status.")
-        if not self._is_logged_in:
-            logger.warning("Validation failed: User is not logged in.")
-            raise PermissionError("User is not logged in. Please call 'login_with_cookies' first.")
-        logger.debug("Validation successful: User is logged in.")
-
-
-class AsyncAuthService(AsyncBaseSkoobService):  # pragma: no cover - thin async wrapper
-    """Asynchronous authentication service."""
-
-    def __init__(self, client: AsyncHTTPClient):
-        super().__init__(client)
-        self._is_logged_in = False
-
-    async def login_with_cookies(self, session_token: str) -> User:
-        """Log in using a pre-existing session token.
-
-        Parameters
-        ----------
-        session_token : str
-            The PHPSESSID token from Skoob.
-
-        Returns
-        -------
-        User
-            The authenticated user's information.
-        """
-
-        logger.info("Attempting to log in with session token.")
-        self.client.cookies.update({"PHPSESSID": session_token})
-        user = await self.get_my_info()
-        self._is_logged_in = True
-        logger.info("Successfully logged in as user: '%s'", user.name)
-        return user
-
-    async def login(self, email: str, password: str) -> User:
-        """Log in using email and password.
-
-        Parameters
-        ----------
-        email : str
-            The user's email address.
-        password : str
-            The user's password.
-
-        Returns
-        -------
-        User
-            The authenticated user's information.
-        """
-
-        logger.info("Attempting to log in with email and password.")
-        url = f"{self.base_url}/v1/login"
-        data = {
-            "data[Usuario][email]": email,
-            "data[Usuario][senha]": password,
-            "data[Login][automatico]": True,
-        }
-        response = await self.client.post(url, data=data)
+        response = await maybe_await(self.client.post, url, data=data)
         response.raise_for_status()
         try:
             json_data = response.json()
@@ -239,24 +47,16 @@ class AsyncAuthService(AsyncBaseSkoobService):  # pragma: no cover - thin async 
             raise ConnectionError("Invalid response format") from exc
         if not json_data.get("success", False):
             logger.error("Login failed: %s", json_data.get("message", "Unknown error"))
-            raise ConnectionError("Failed to login: {}".format(json_data.get("message", "Unknown error")))
+            raise ConnectionError(f"Failed to login: {json_data.get('message', 'Unknown error')}")
         self._is_logged_in = True
-        user = await self.get_my_info()
+        user = await self._get_my_info()
         logger.info("Successfully logged in as user: '%s'", user.name)
         return user
 
-    async def get_my_info(self) -> User:
-        """Retrieve information about the authenticated user.
-
-        Returns
-        -------
-        User
-            The authenticated user's information.
-        """
-
+    async def _get_my_info(self) -> User:
         logger.info("Getting authenticated user's information.")
         url = f"{self.base_url}/v1/user/stats:true"
-        response = await self.client.get(url)
+        response = await maybe_await(self.client.get, url)
         response.raise_for_status()
         json_data = response.json()
         if not json_data.get("success"):
@@ -268,22 +68,67 @@ class AsyncAuthService(AsyncBaseSkoobService):  # pragma: no cover - thin async 
         logger.info("Successfully retrieved user: '%s'", user.name)
         return user
 
-    async def validate_login(self) -> None:
-        """Validate that the current session is authenticated.
-
-        Notes
-        -----
-        This method performs no I/O but remains asynchronous for API
-        consistency across async services.
-
-        Raises
-        ------
-        PermissionError
-            If the user is not logged in.
-        """
-
+    def _validate_login(self) -> None:
         logger.debug("Validating login status.")
         if not self._is_logged_in:
             logger.warning("Validation failed: User is not logged in.")
             raise PermissionError("User is not logged in. Please call 'login_with_cookies' first.")
         logger.debug("Validation successful: User is logged in.")
+
+
+class AuthService(_AuthServiceMixin, BaseSkoobService):
+    """Handle authentication with Skoob and track login state."""
+
+    def __init__(self, client: SyncHTTPClient):
+        """Manage Skoob authentication and session validation."""
+
+        super().__init__(client)
+        self._is_logged_in = False
+
+    def login_with_cookies(self, session_token: str) -> User:
+        """Log in using a pre-existing session token."""
+
+        return run_sync(self._login_with_cookies(session_token))
+
+    def login(self, email: str, password: str) -> User:
+        """Log in with email and password."""
+
+        return run_sync(self._login(email, password))
+
+    def get_my_info(self) -> User:
+        """Retrieve information about the authenticated user."""
+
+        return run_sync(self._get_my_info())
+
+    def validate_login(self) -> None:
+        """Validate that the current session is authenticated."""
+
+        self._validate_login()
+
+
+class AsyncAuthService(_AuthServiceMixin, AsyncBaseSkoobService):  # pragma: no cover - thin async wrapper
+    """Asynchronous authentication service."""
+
+    def __init__(self, client: AsyncHTTPClient):
+        super().__init__(client)
+        self._is_logged_in = False
+
+    async def login_with_cookies(self, session_token: str) -> User:
+        """Log in using a pre-existing session token."""
+
+        return await self._login_with_cookies(session_token)
+
+    async def login(self, email: str, password: str) -> User:
+        """Log in with email and password."""
+
+        return await self._login(email, password)
+
+    async def get_my_info(self) -> User:
+        """Retrieve information about the authenticated user."""
+
+        return await self._get_my_info()
+
+    async def validate_login(self) -> None:
+        """Validate that the current session is authenticated."""
+
+        self._validate_login()

--- a/pyskoob/books.py
+++ b/pyskoob/books.py
@@ -2,6 +2,8 @@
 
 import logging
 import re
+from collections.abc import Callable
+from typing import Any
 
 from pydantic import ValidationError
 
@@ -24,61 +26,32 @@ from pyskoob.utils.bs4_utils import (
     safe_find,
     safe_find_all,
 )
+from pyskoob.utils.sync_async import maybe_await, run_sync
 
 logger = logging.getLogger(__name__)
 
 
-class BookService(BaseSkoobService):
-    """High level operations for retrieving and searching books.
+class _BookServiceMixin:
+    """Shared book retrieval logic for sync and async services."""
 
-    The service parses HTML and JSON responses from Skoob and exposes
-    helpers to fetch book details, reviews and user lists. It can be used
-    independently from authentication, but other services may combine it
-    with :class:`AuthService` to operate on the authenticated user's data.
-    """
+    client: Any
+    base_url: str
+    parse_html: Callable[[str], Any]
 
-    def search(
+    async def _search(
         self,
         query: str,
         search_by: BookSearch = BookSearch.TITLE,
         page: int = 1,
     ) -> Pagination[BookSearchResult]:
-        """
-        Searches for books by query and type.
+        """Search for books by ``query`` and ``search_by`` criteria."""
 
-        Parameters
-        ----------
-        query : str
-            The search query string.
-        search_by : BookSearch, optional
-            The type of search (title, author, etc.), by default
-            ``BookSearch.TITLE``.
-        page : int, optional
-            The page number for pagination, by default 1.
-
-        Returns
-        -------
-        Pagination[BookSearchResult]
-            A paginated list of search results.
-
-        Raises
-        ------
-        RequestError
-            If the HTTP request fails.
-        ParsingError
-            If the HTML structure changes and parsing fails.
-
-        Examples
-        --------
-        >>> service.search("Duna").results[0].title
-        'Duna'
-        """
         url = f"{self.base_url}/livro/lista/busca:{query}/tipo:{search_by.value}/mpage:{page}"
         logger.info("Searching for books with query: '%s' on page %s", query, page)
         try:
-            response = self.client.get(url)
+            response = await maybe_await(self.client.get, url)
             response.raise_for_status()
-        except Exception as e:
+        except Exception as e:  # pragma: no cover - defensive
             logger.error("Request error during book search: %s", e, exc_info=True)
             raise RequestError("Failed to search books.") from e
 
@@ -95,13 +68,9 @@ class BookService(BaseSkoobService):
         except (AttributeError, ValueError, IndexError, TypeError) as e:  # pragma: no cover - defensive
             logger.error("Failed to parse book search results: %s", e, exc_info=True)
             raise ParsingError("Failed to parse book search results.") from e
-        except Exception as e:  # pragma: no cover - unexpected
-            logger.error(
-                "An unexpected error occurred during book search: %s",
-                e,
-                exc_info=True,
-            )
-            raise ParsingError("An unexpected error occurred during book search.") from e
+        except Exception:  # pragma: no cover - unexpected
+            logger.exception("Unexpected error during book search")
+            raise
 
         logger.info(
             "Found %s books on page %s, total %s results.",
@@ -117,40 +86,15 @@ class BookService(BaseSkoobService):
             has_next_page=next_page_link,
         )
 
-    def get_by_id(self, edition_id: int) -> Book:
-        """
-        Retrieves a book by its edition ID.
+    async def _get_by_id(self, edition_id: int) -> Book:
+        """Retrieve a book by its edition identifier."""
 
-        Parameters
-        ----------
-        edition_id : int
-            The edition ID of the book.
-
-        Returns
-        -------
-        Book
-            Book object populated with detailed information.
-
-        Raises
-        ------
-        FileNotFoundError
-            If no book is found with the given edition_id.
-        RequestError
-            If the HTTP request fails.
-        ParsingError
-            If parsing of the response fails.
-
-        Examples
-        --------
-        >>> service.get_by_id(1).title
-        'Some Book'
-        """
         logger.info("Getting book by edition_id: %s", edition_id)
         url = f"{self.base_url}/v1/book/{edition_id}/stats:true"
         try:
-            response = self.client.get(url)
+            response = await maybe_await(self.client.get, url)
             response.raise_for_status()
-        except Exception as e:
+        except Exception as e:  # pragma: no cover - defensive
             logger.error(
                 "Request error retrieving book for edition_id %s: %s",
                 edition_id,
@@ -185,40 +129,15 @@ class BookService(BaseSkoobService):
             )
             raise ParsingError(f"Failed to retrieve book for edition_id {edition_id}.") from e
 
-    def get_reviews(self, book_id: int, edition_id: int | None = None, page: int = 1) -> Pagination[BookReview]:
-        """
-        Retrieves reviews for a book.
+    async def _get_reviews(self, book_id: int, edition_id: int | None = None, page: int = 1) -> Pagination[BookReview]:
+        """Fetch reviews for a given book."""
 
-        Parameters
-        ----------
-        book_id : int
-            Book ID for which to retrieve reviews.
-        edition_id : int or None, optional
-            Specific edition ID, or auto-detected if None.
-        page : int, optional
-            Page number for pagination, by default 1.
-
-        Returns
-        -------
-        Pagination[BookReview]
-            A paginated list of reviews for the book.
-
-        Raises
-        ------
-        ParsingError
-            If the HTML structure changes or parsing fails.
-
-        Examples
-        --------
-        >>> service.get_reviews(123).results
-        [...]
-        """
         url = f"{self.base_url}/livro/resenhas/{book_id}/mpage:{page}/limit:50"
         if edition_id:
             url += f"/edition:{edition_id}"
         logger.info("Getting reviews for book_id: %s, page: %s", book_id, page)
         try:
-            response = self.client.get(url)
+            response = await maybe_await(self.client.get, url)
             response.raise_for_status()
             soup = self.parse_html(response.text)
             if edition_id is None:
@@ -248,7 +167,7 @@ class BookService(BaseSkoobService):
             has_next_page=next_page_link is not None,
         )
 
-    def get_users_by_status(
+    async def _get_users_by_status(
         self,
         book_id: int,
         status: BookUserStatus,
@@ -256,37 +175,8 @@ class BookService(BaseSkoobService):
         limit: int = 500,
         page: int = 1,
     ) -> Pagination[int]:
-        """
-        Retrieves users who have a book with a specific status.
+        """Fetch user IDs who marked the book with a given status."""
 
-        Parameters
-        ----------
-        book_id : int
-            The ID of the book.
-        status : BookUserStatus
-            The status of the book in the user's shelf.
-        edition_id : int or None, optional
-            The edition ID of the book, by default None.
-        limit : int, optional
-            The number of users to retrieve per page, by default 500.
-        page : int, optional
-            The page number for pagination, by default 1.
-
-        Returns
-        -------
-        Pagination[int]
-            A paginated list of user IDs.
-
-        Raises
-        ------
-        ParsingError
-            If the HTML structure changes and parsing fails.
-
-        Examples
-        --------
-        >>> service.get_users_by_status(1, BookUserStatus.READERS).results[:3]
-        [1, 2, 3]
-        """
         url = f"{self.base_url}/livro/leitores/{status.value}/{book_id}/limit:{limit}/page:{page}"
         if edition_id:
             url += f"/edition:{edition_id}"
@@ -297,7 +187,7 @@ class BookService(BaseSkoobService):
             page,
         )
         try:
-            response = self.client.get(url)
+            response = await maybe_await(self.client.get, url)
             response.raise_for_status()
             soup = self.parse_html(response.text)
             users_id = extract_user_ids_from_html(soup)
@@ -326,161 +216,55 @@ class BookService(BaseSkoobService):
         )
 
 
-class AsyncBookService(AsyncBaseSkoobService):  # pragma: no cover - thin async wrapper
+class BookService(_BookServiceMixin, BaseSkoobService):
+    """High level operations for retrieving and searching books."""
+
+    def search(
+        self,
+        query: str,
+        search_by: BookSearch = BookSearch.TITLE,
+        page: int = 1,
+    ) -> Pagination[BookSearchResult]:
+        """Searches for books by query and type."""
+        return run_sync(self._search(query, search_by, page))
+
+    def get_by_id(self, edition_id: int) -> Book:
+        """Retrieves a book by its edition ID."""
+        return run_sync(self._get_by_id(edition_id))
+
+    def get_reviews(self, book_id: int, edition_id: int | None = None, page: int = 1) -> Pagination[BookReview]:
+        """Retrieves reviews for a book."""
+        return run_sync(self._get_reviews(book_id, edition_id, page))
+
+    def get_users_by_status(
+        self,
+        book_id: int,
+        status: BookUserStatus,
+        edition_id: int | None = None,
+        limit: int = 500,
+        page: int = 1,
+    ) -> Pagination[int]:
+        """Retrieves users who have a book with a specific status."""
+        return run_sync(self._get_users_by_status(book_id, status, edition_id, limit, page))
+
+
+class AsyncBookService(_BookServiceMixin, AsyncBaseSkoobService):  # pragma: no cover - thin async wrapper
     """Asynchronous variant of :class:`BookService`."""
 
     def __init__(self, client: AsyncHTTPClient):
         super().__init__(client)
 
     async def search(self, query: str, search_by: BookSearch = BookSearch.TITLE, page: int = 1) -> Pagination[BookSearchResult]:
-        """Asynchronously search for books by query and type.
-
-        Parameters
-        ----------
-        query : str
-            The search query string.
-        search_by : BookSearch, optional
-            Type of search (title, author, etc.), by default ``BookSearch.TITLE``.
-        page : int, optional
-            Page number for pagination, by default ``1``.
-
-        Returns
-        -------
-        Pagination[BookSearchResult]
-            Paginated list of search results.
-        """
-
-        url = f"{self.base_url}/livro/lista/busca:{query}/tipo:{search_by.value}/mpage:{page}"
-        logger.info("Searching for books with query: '%s' on page %s", query, page)
-        try:
-            response = await self.client.get(url)
-            response.raise_for_status()
-            soup = self.parse_html(response.text)
-            limit = 30
-            results = [
-                parse_search_result(book_div, self.base_url)
-                for book_div in safe_find_all(soup, "div", {"class": "box_lista_busca_vertical"})
-            ]
-            cleaned_results: list[BookSearchResult] = [i for i in results if i]
-            total_results = extract_total_results(soup)
-            next_page_link = True if page * limit < total_results else False
-            logger.info(
-                "Found %s books on page %s, total %s results.",
-                len(results),
-                page,
-                total_results,
-            )
-            return Pagination[BookSearchResult](
-                results=cleaned_results,
-                limit=30,
-                page=page,
-                total=total_results,
-                has_next_page=next_page_link,
-            )
-        except Exception as exc:  # pragma: no cover - defensive
-            logger.error("Failed to search books: %s", exc, exc_info=True)
-            return Pagination[BookSearchResult](
-                results=[],
-                limit=30,
-                page=page,
-                total=0,
-                has_next_page=False,
-            )
+        """Asynchronously search for books by query and type."""
+        return await self._search(query, search_by, page)
 
     async def get_by_id(self, edition_id: int) -> Book:
-        """Retrieve a book by its edition ID asynchronously.
-
-        Parameters
-        ----------
-        edition_id : int
-            The edition identifier of the book.
-
-        Returns
-        -------
-        Book
-            The book details for the given edition.
-        """
-
-        logger.info("Getting book by edition_id: %s", edition_id)
-        url = f"{self.base_url}/v1/book/{edition_id}/stats:true"
-        try:
-            response = await self.client.get(url)
-            response.raise_for_status()
-            json_data = response.json().get("response")
-            if not json_data:
-                cod_description = response.json().get("cod_description", "No description provided.")
-                error_msg = f"No data found for edition_id {edition_id}. Description: {cod_description}"
-                logger.warning(error_msg)
-                raise FileNotFoundError(error_msg)
-            json_data = clean_book_json_data(json_data, self.base_url)
-            book = Book.model_validate(json_data)
-            logger.info(
-                "Successfully retrieved book: '%s' (Edition ID: %s)",
-                book.title,
-                edition_id,
-            )
-            return book
-        except FileNotFoundError:
-            raise
-        except Exception as exc:  # pragma: no cover - defensive
-            logger.error(
-                "Failed to retrieve book for edition_id %s: %s",
-                edition_id,
-                exc,
-                exc_info=True,
-            )
-            raise ParsingError("Failed to retrieve book.") from exc
+        """Retrieve a book by its edition ID asynchronously."""
+        return await self._get_by_id(edition_id)
 
     async def get_reviews(self, book_id: int, edition_id: int | None = None, page: int = 1) -> Pagination[BookReview]:
-        """Retrieve book reviews asynchronously.
-
-        Parameters
-        ----------
-        book_id : int
-            Identifier of the book.
-        edition_id : int, optional
-            Specific edition to filter reviews, by default ``None``.
-        page : int, optional
-            Pagination page, by default ``1``.
-
-        Returns
-        -------
-        Pagination[BookReview]
-            Paginated list of book reviews.
-        """
-
-        url = f"{self.base_url}/livro/resenhas/{book_id}/mpage:{page}/limit:50"
-        if edition_id:
-            url += f"/edition:{edition_id}"
-        logger.info("Getting reviews for book_id: %s, page: %s", book_id, page)
-        try:
-            response = await self.client.get(url)
-            response.raise_for_status()
-            soup = self.parse_html(response.text)
-            if edition_id is None:
-                edition_id = extract_edition_id_from_reviews_page(soup)
-            book_reviews = [
-                review
-                for review in (parse_review(r, book_id, edition_id) for r in safe_find_all(soup, "div", {"id": re.compile(r"resenha\d+")}))
-                if review is not None
-            ]
-            next_page_link = safe_find(soup, "a", {"class": "proximo"})
-            logger.info("Found %s reviews on page %s.", len(book_reviews), page)
-            return Pagination[BookReview](
-                results=book_reviews,
-                limit=50,
-                page=page,
-                total=len(book_reviews),
-                has_next_page=next_page_link is not None,
-            )
-        except Exception as exc:  # pragma: no cover - defensive
-            logger.error(
-                "Failed to retrieve book reviews for book_id %s: %s",
-                book_id,
-                exc,
-                exc_info=True,
-            )
-            raise ParsingError("Failed to retrieve book reviews.") from exc
+        """Retrieve book reviews asynchronously."""
+        return await self._get_reviews(book_id, edition_id, page)
 
     async def get_users_by_status(
         self,
@@ -490,57 +274,5 @@ class AsyncBookService(AsyncBaseSkoobService):  # pragma: no cover - thin async 
         limit: int = 500,
         page: int = 1,
     ) -> Pagination[int]:
-        """Retrieve user IDs who marked the book with a given status.
-
-        Parameters
-        ----------
-        book_id : int
-            Identifier of the book.
-        status : BookUserStatus
-            User status to filter by (read, reading, etc.).
-        edition_id : int, optional
-            Specific edition to filter, by default ``None``.
-        limit : int, optional
-            Maximum number of users per page, by default ``500``.
-        page : int, optional
-            Page number for pagination, by default ``1``.
-
-        Returns
-        -------
-        Pagination[int]
-            Paginated list of user IDs.
-        """
-
-        url = f"{self.base_url}/livro/leitores/{status.value}/{book_id}/limit:{limit}/page:{page}"
-        if edition_id:
-            url += f"/edition:{edition_id}"
-        logger.info(
-            "Getting users for book_id: %s with status '%s' on page %s",
-            book_id,
-            status.value,
-            page,
-        )
-        try:
-            response = await self.client.get(url)
-            response.raise_for_status()
-            soup = self.parse_html(response.text)
-            users_id = extract_user_ids_from_html(soup)
-            next_page_link = safe_find(soup, "a", {"class": "proximo"})
-            logger.info("Found %s users on page %s.", len(users_id), page)
-            return Pagination[int](
-                results=users_id,
-                limit=limit,
-                page=page,
-                total=len(users_id),
-                has_next_page=next_page_link is not None,
-            )
-        except (AttributeError, ValueError, IndexError, TypeError) as exc:  # pragma: no cover - defensive
-            logger.error("Failed to parse users by status: %s", exc, exc_info=True)
-            raise ParsingError("Failed to parse users by status.") from exc
-        except Exception as exc:  # pragma: no cover - unexpected
-            logger.error(
-                "An unexpected error occurred while retrieving users by status: %s",
-                exc,
-                exc_info=True,
-            )
-            raise ParsingError("An unexpected error occurred while retrieving users by status.") from exc
+        """Retrieve user IDs who marked the book with a given status."""
+        return await self._get_users_by_status(book_id, status, edition_id, limit, page)

--- a/pyskoob/profile.py
+++ b/pyskoob/profile.py
@@ -1,17 +1,86 @@
 """Profile management helpers for authenticated Skoob users."""
 
 import logging
+from collections.abc import Callable
+from typing import Any
 
 from pyskoob.auth import AsyncAuthService, AuthService
 from pyskoob.http.client import AsyncHTTPClient, SyncHTTPClient
 from pyskoob.internal.async_authenticated import AsyncAuthenticatedService
 from pyskoob.internal.authenticated import AuthenticatedService
 from pyskoob.models.enums import BookLabel, BookShelf, BookStatus
+from pyskoob.utils.sync_async import maybe_await, run_sync
 
 logger = logging.getLogger(__name__)
 
 
-class SkoobProfileService(AuthenticatedService):
+class _ProfileServiceMixin:
+    """Shared profile actions for sync and async services."""
+
+    client: Any
+    base_url: str
+    _validate_login: Callable[[], Any]
+
+    async def _add_book_label(self, edition_id: int, label: BookLabel) -> bool:
+        """Add a label to a book."""
+
+        await maybe_await(self._validate_login)
+        url = f"{self.base_url}/v1/label_add/{edition_id}/{label.value}"
+        response = await maybe_await(self.client.get, url)
+        response.raise_for_status()
+        return response.json().get("success", False)
+
+    async def _remove_book_label(self, edition_id: int) -> bool:
+        """Remove a label from a book."""
+
+        await maybe_await(self._validate_login)
+        url = f"{self.base_url}/v1/label_del/{edition_id}"
+        response = await maybe_await(self.client.get, url)
+        response.raise_for_status()
+        return response.json().get("success", False)
+
+    async def _update_book_status(self, edition_id: int, status: BookStatus) -> bool:
+        """Update the user's status for a book."""
+
+        await maybe_await(self._validate_login)
+        url = f"{self.base_url}/v1/shelf_add/{edition_id}/{status.value}"
+        response = await maybe_await(self.client.get, url)
+        response.raise_for_status()
+        return response.json().get("success", False)
+
+    async def _remove_book_status(self, edition_id: int) -> bool:
+        """Remove the user's status for a book."""
+
+        await maybe_await(self._validate_login)
+        url = f"{self.base_url}/v1/shelf_del/{edition_id}"
+        response = await maybe_await(self.client.get, url)
+        response.raise_for_status()
+        return response.json().get("success", False)
+
+    async def _change_book_shelf(self, edition_id: int, bookshelf: BookShelf) -> bool:
+        """Move a book to a different bookshelf."""
+
+        await maybe_await(self._validate_login)
+        url = f"{self.base_url}/estante/prateleira/{edition_id}/{bookshelf.value}"
+        response = await maybe_await(self.client.get, url)
+        response.raise_for_status()
+        return response.json().get("success", False)
+
+    async def _rate_book(self, edition_id: int, ranking: float) -> bool:
+        """Rate a book in the authenticated profile."""
+
+        await maybe_await(self._validate_login)
+        if not (0 <= ranking <= 5):
+            raise ValueError("Rating must be between 0 and 5.")
+        url = f"{self.base_url}/v1/book_rate/{edition_id}/{ranking}"
+        response = await maybe_await(self.client.get, url)
+        response.raise_for_status()
+        if not response.json().get("success"):
+            raise RuntimeError("Failed to rate the book.")
+        return True
+
+
+class SkoobProfileService(_ProfileServiceMixin, AuthenticatedService):
     """Perform profile-related actions such as labeling and rating books."""
 
     def __init__(self, client: SyncHTTPClient, auth_service: AuthService):
@@ -52,11 +121,7 @@ class SkoobProfileService(AuthenticatedService):
         >>> service.add_book_label(10, BookLabel.FAVORITE)
         True
         """
-        self._validate_login()
-        url = f"{self.base_url}/v1/label_add/{edition_id}/{label.value}"
-        response = self.client.get(url)
-        response.raise_for_status()
-        return response.json().get("success", False)
+        return run_sync(self._add_book_label(edition_id, label))
 
     def remove_book_label(self, edition_id: int) -> bool:
         """
@@ -77,11 +142,7 @@ class SkoobProfileService(AuthenticatedService):
         >>> service.remove_book_label(10)
         True
         """
-        self._validate_login()
-        url = f"{self.base_url}/v1/label_del/{edition_id}"
-        response = self.client.get(url)
-        response.raise_for_status()
-        return response.json().get("success", False)
+        return run_sync(self._remove_book_label(edition_id))
 
     def update_book_status(self, edition_id: int, status: BookStatus) -> bool:
         """
@@ -104,11 +165,7 @@ class SkoobProfileService(AuthenticatedService):
         >>> service.update_book_status(10, BookStatus.READ)
         True
         """
-        self._validate_login()
-        url = f"{self.base_url}/v1/shelf_add/{edition_id}/{status.value}"
-        response = self.client.get(url)
-        response.raise_for_status()
-        return response.json().get("success", False)
+        return run_sync(self._update_book_status(edition_id, status))
 
     def remove_book_status(self, edition_id: int) -> bool:
         """
@@ -129,11 +186,7 @@ class SkoobProfileService(AuthenticatedService):
         >>> service.remove_book_status(10)
         True
         """
-        self._validate_login()
-        url = f"{self.base_url}/v1/shelf_del/{edition_id}"
-        response = self.client.get(url)
-        response.raise_for_status()
-        return response.json().get("success", False)
+        return run_sync(self._remove_book_status(edition_id))
 
     def change_book_shelf(self, edition_id: int, bookshelf: BookShelf) -> bool:
         """
@@ -156,11 +209,7 @@ class SkoobProfileService(AuthenticatedService):
         >>> service.change_book_shelf(10, BookShelf.FAVORITES)
         True
         """
-        self._validate_login()
-        url = f"{self.base_url}/estante/prateleira/{edition_id}/{bookshelf.value}"
-        response = self.client.get(url)
-        response.raise_for_status()
-        return response.json().get("success", False)
+        return run_sync(self._change_book_shelf(edition_id, bookshelf))
 
     def rate_book(self, edition_id: int, ranking: float) -> bool:
         """
@@ -190,160 +239,41 @@ class SkoobProfileService(AuthenticatedService):
         >>> service.rate_book(10, 4.5)
         True
         """
-        self._validate_login()
-        if not (0 <= ranking <= 5):
-            raise ValueError("Rating must be between 0 and 5.")
-
-        url = f"{self.base_url}/v1/book_rate/{edition_id}/{ranking}"
-        response = self.client.get(url)
-        response.raise_for_status()
-
-        if not response.json().get("success"):
-            raise RuntimeError("Failed to rate the book.")
-        return True
+        return run_sync(self._rate_book(edition_id, ranking))
 
 
-class AsyncSkoobProfileService(AsyncAuthenticatedService):  # pragma: no cover - thin async wrapper
+class AsyncSkoobProfileService(_ProfileServiceMixin, AsyncAuthenticatedService):  # pragma: no cover - thin async wrapper
     """Asynchronous variant of :class:`SkoobProfileService`."""
 
     def __init__(self, client: AsyncHTTPClient, auth_service: AsyncAuthService):
         super().__init__(client, auth_service)
 
     async def add_book_label(self, edition_id: int, label: BookLabel) -> bool:
-        """Add a label to a book in the authenticated profile.
+        """Add a label to a book in the authenticated profile."""
 
-        Parameters
-        ----------
-        edition_id : int
-            The edition identifier.
-        label : BookLabel
-            Label to apply to the book.
-
-        Returns
-        -------
-        bool
-            ``True`` if the operation succeeded.
-        """
-
-        await self._validate_login()
-        url = f"{self.base_url}/v1/label_add/{edition_id}/{label.value}"
-        response = await self.client.get(url)
-        response.raise_for_status()
-        return response.json().get("success", False)
+        return await self._add_book_label(edition_id, label)
 
     async def remove_book_label(self, edition_id: int) -> bool:
-        """Remove a label from a book in the authenticated profile.
+        """Remove a label from a book in the authenticated profile."""
 
-        Parameters
-        ----------
-        edition_id : int
-            The edition identifier.
-
-        Returns
-        -------
-        bool
-            ``True`` if the operation succeeded.
-        """
-
-        await self._validate_login()
-        url = f"{self.base_url}/v1/label_del/{edition_id}"
-        response = await self.client.get(url)
-        response.raise_for_status()
-        return response.json().get("success", False)
+        return await self._remove_book_label(edition_id)
 
     async def update_book_status(self, edition_id: int, status: BookStatus) -> bool:
-        """Update the user's status for a book.
+        """Update the user's status for a book."""
 
-        Parameters
-        ----------
-        edition_id : int
-            The edition identifier.
-        status : BookStatus
-            New status to assign to the book.
-
-        Returns
-        -------
-        bool
-            ``True`` if the status update succeeded.
-        """
-
-        await self._validate_login()
-        url = f"{self.base_url}/v1/shelf_add/{edition_id}/{status.value}"
-        response = await self.client.get(url)
-        response.raise_for_status()
-        return response.json().get("success", False)
+        return await self._update_book_status(edition_id, status)
 
     async def remove_book_status(self, edition_id: int) -> bool:
-        """Remove the user's status for a book.
+        """Remove the user's status for a book."""
 
-        Parameters
-        ----------
-        edition_id : int
-            The edition identifier.
-
-        Returns
-        -------
-        bool
-            ``True`` if the status was removed successfully.
-        """
-
-        await self._validate_login()
-        url = f"{self.base_url}/v1/shelf_del/{edition_id}"
-        response = await self.client.get(url)
-        response.raise_for_status()
-        return response.json().get("success", False)
+        return await self._remove_book_status(edition_id)
 
     async def change_book_shelf(self, edition_id: int, bookshelf: BookShelf) -> bool:
-        """Move a book to a different bookshelf.
+        """Move a book to a different bookshelf."""
 
-        Parameters
-        ----------
-        edition_id : int
-            The edition identifier.
-        bookshelf : BookShelf
-            Target bookshelf.
-
-        Returns
-        -------
-        bool
-            ``True`` if the operation succeeded.
-        """
-
-        await self._validate_login()
-        url = f"{self.base_url}/estante/prateleira/{edition_id}/{bookshelf.value}"
-        response = await self.client.get(url)
-        response.raise_for_status()
-        return response.json().get("success", False)
+        return await self._change_book_shelf(edition_id, bookshelf)
 
     async def rate_book(self, edition_id: int, ranking: float) -> bool:
-        """Rate a book in the authenticated profile.
+        """Rate a book in the authenticated profile."""
 
-        Parameters
-        ----------
-        edition_id : int
-            The edition identifier.
-        ranking : float
-            Rating between 0 and 5.
-
-        Returns
-        -------
-        bool
-            ``True`` if the rating was saved.
-
-        Raises
-        ------
-        ValueError
-            If ``ranking`` is outside the 0–5 range.
-        RuntimeError
-            If Skoob rejects the rating.
-        """
-
-        await self._validate_login()
-        if not (0 <= ranking <= 5):
-            raise ValueError("Rating must be between 0 and 5.")
-        url = f"{self.base_url}/v1/book_rate/{edition_id}/{ranking}"
-        response = await self.client.get(url)
-        response.raise_for_status()
-        if not response.json().get("success"):
-            raise RuntimeError("Failed to rate the book.")
-        return True
+        return await self._rate_book(edition_id, ranking)

--- a/pyskoob/publishers.py
+++ b/pyskoob/publishers.py
@@ -1,11 +1,9 @@
 """Retrieve publisher information, books and authors from Skoob."""
 
 import logging
-from typing import cast
+from collections.abc import Callable
+from typing import Any
 
-from bs4 import Tag
-
-from pyskoob.exceptions import ParsingError
 from pyskoob.http.client import AsyncHTTPClient
 from pyskoob.internal.async_base import AsyncBaseSkoobService
 from pyskoob.internal.base import BaseSkoobService
@@ -22,304 +20,107 @@ from pyskoob.utils.bs4_utils import (
     safe_find,
     safe_find_all,
 )
+from pyskoob.utils.sync_async import maybe_await, run_sync
 
 logger = logging.getLogger(__name__)
 
 
-class PublisherService(BaseSkoobService):
+class _PublisherServiceMixin:
+    """Shared publisher retrieval logic for sync and async services.
+
+    This mixin expects ``client``, ``base_url`` and ``parse_html`` attributes to
+    be provided by the consuming base classes.
+    """
+
+    client: Any
+    base_url: str
+    parse_html: Callable[[str], Any]
+
+    async def _get_by_id(self, publisher_id: int) -> Publisher:
+        url = f"{self.base_url}/editora/{publisher_id}"
+        logger.info("Fetching publisher page: %s", url)
+        response = await maybe_await(self.client.get, url)
+        response.raise_for_status()
+        soup = self.parse_html(response.text)
+        name = get_tag_text(safe_find(soup, "h2")) or get_tag_text(soup.title)
+        description = get_tag_text(safe_find(soup, "div", {"id": "historico"}))
+        site_link = soup.find("a", string="Site oficial")
+        website = get_tag_attr(site_link, "href")
+        stats = parse_stats(safe_find(soup, "div", {"id": "vt_estatisticas"}))
+        releases_div = safe_find(soup, "div", {"id": "livros_lancamentos"})
+        releases = [parse_book(div, self.base_url) for div in safe_find_all(releases_div, "div", {"class": "livro-capa-mini"})]
+        return Publisher(
+            id=publisher_id,
+            name=name,
+            description=description,
+            website=website,
+            stats=stats,
+            last_releases=releases,
+        )
+
+    async def _get_authors(self, publisher_id: int, page: int = 1) -> Pagination[PublisherAuthor]:
+        url = f"{self.base_url}/editora/autores/{publisher_id}/mpage:{page}"
+        logger.info("Fetching publisher authors: %s", url)
+        response = await maybe_await(self.client.get, url)
+        response.raise_for_status()
+        soup = self.parse_html(response.text)
+        authors = [parse_author(div, self.base_url) for div in safe_find_all(soup, "div", {"class": "box_autor"})]
+        next_page = bool(safe_find(soup, "div", {"class": "proximo"}))
+        return Pagination(
+            results=authors,
+            limit=len(authors),
+            page=page,
+            total=len(authors),
+            has_next_page=next_page,
+        )
+
+    async def _get_books(self, publisher_id: int, page: int = 1) -> Pagination[PublisherItem]:
+        url = f"{self.base_url}/editora/livros/{publisher_id}/mpage:{page}"
+        logger.info("Fetching publisher books: %s", url)
+        response = await maybe_await(self.client.get, url)
+        response.raise_for_status()
+        soup = self.parse_html(response.text)
+        books = [parse_book(div, self.base_url) for div in safe_find_all(soup, "div", {"class": "box_livro"})]
+        next_page = bool(safe_find(soup, "div", {"class": "proximo"}))
+        return Pagination(
+            results=books,
+            limit=len(books),
+            page=page,
+            total=len(books),
+            has_next_page=next_page,
+        )
+
+
+class PublisherService(_PublisherServiceMixin, BaseSkoobService):
     """High level operations for retrieving publishers."""
 
     def get_by_id(self, publisher_id: int) -> Publisher:
-        """Retrieve detailed information about a publisher.
-
-        Parameters
-        ----------
-        publisher_id : int
-            The identifier of the publisher on Skoob.
-
-        Returns
-        -------
-        Publisher
-            An object containing information about the publisher, including
-            statistics and recently released books.
-
-        Raises
-        ------
-        ParsingError
-            If the expected elements cannot be parsed from the page.
-
-        Examples
-        --------
-        >>> service.get_by_id(1).name
-        'Editora Exemplo'
-        """
-        url = f"{self.base_url}/editora/{publisher_id}"
-        logger.info("Fetching publisher page: %s", url)
-        try:
-            response = self.client.get(url)
-            response.raise_for_status()
-            soup = self.parse_html(response.text)
-            name = get_tag_text(safe_find(soup, "h2")) or get_tag_text(soup.title)
-            description = get_tag_text(safe_find(soup, "div", {"id": "historico"}))
-            site_link = cast(Tag | None, soup.find("a", string="Site oficial"))
-            website = get_tag_attr(site_link, "href")
-            stats = parse_stats(safe_find(soup, "div", {"id": "vt_estatisticas"}))
-            releases_div = safe_find(soup, "div", {"id": "livros_lancamentos"})
-            releases = [parse_book(div, self.base_url) for div in safe_find_all(releases_div, "div", {"class": "livro-capa-mini"})]
-            return Publisher(
-                id=publisher_id,
-                name=name,
-                description=description,
-                website=website,
-                stats=stats,
-                last_releases=releases,
-            )
-        except (AttributeError, TypeError, ValueError) as exc:  # pragma: no cover - defensive
-            logger.error("Failed to parse publisher page: %s", exc, exc_info=True)
-            raise ParsingError("Failed to parse publisher page.") from exc
-        except Exception as exc:  # pragma: no cover - unexpected
-            logger.error(
-                "An unexpected error occurred while parsing publisher page: %s",
-                exc,
-                exc_info=True,
-            )
-            raise ParsingError("An unexpected error occurred while parsing publisher page.") from exc
+        """Retrieve detailed information about a publisher."""
+        return run_sync(self._get_by_id(publisher_id))
 
     def get_authors(self, publisher_id: int, page: int = 1) -> Pagination[PublisherAuthor]:
-        """Retrieve authors associated with a publisher.
-
-        Parameters
-        ----------
-        publisher_id : int
-            The identifier of the publisher on Skoob.
-        page : int, optional
-            The pagination page to retrieve, by default 1.
-
-        Returns
-        -------
-        Pagination[PublisherAuthor]
-            A paginated list of authors published by the publisher.
-
-        Raises
-        ------
-        ParsingError
-            If the HTML structure for authors cannot be parsed.
-
-        Examples
-        --------
-        >>> service.get_authors(1).results[0].name
-        'Autor Exemplo'
-        """
-        url = f"{self.base_url}/editora/autores/{publisher_id}/mpage:{page}"
-        logger.info("Fetching publisher authors: %s", url)
-        try:
-            response = self.client.get(url)
-            response.raise_for_status()
-            soup = self.parse_html(response.text)
-            authors = [parse_author(div, self.base_url) for div in safe_find_all(soup, "div", {"class": "box_autor"})]
-            next_page = bool(safe_find(soup, "div", {"class": "proximo"}))
-            return Pagination(
-                results=authors,
-                limit=len(authors),
-                page=page,
-                total=len(authors),
-                has_next_page=next_page,
-            )
-        except (AttributeError, TypeError, ValueError) as exc:  # pragma: no cover - defensive
-            logger.error("Failed to parse publisher authors: %s", exc, exc_info=True)
-            raise ParsingError("Failed to parse publisher authors.") from exc
-        except Exception as exc:  # pragma: no cover - unexpected
-            logger.error(
-                "An unexpected error occurred while parsing publisher authors: %s",
-                exc,
-                exc_info=True,
-            )
-            raise ParsingError("An unexpected error occurred while parsing publisher authors.") from exc
+        """Retrieve authors associated with a publisher."""
+        return run_sync(self._get_authors(publisher_id, page))
 
     def get_books(self, publisher_id: int, page: int = 1) -> Pagination[PublisherItem]:
-        """Retrieve books published by the publisher.
-
-        Parameters
-        ----------
-        publisher_id : int
-            The identifier of the publisher on Skoob.
-        page : int, optional
-            The pagination page to retrieve, by default 1.
-
-        Returns
-        -------
-        Pagination[PublisherItem]
-            A paginated list of books released by the publisher.
-
-        Raises
-        ------
-        ParsingError
-            If book elements cannot be parsed from the page.
-
-        Examples
-        --------
-        >>> service.get_books(1).results[0].title
-        'Livro Exemplo'
-        """
-        url = f"{self.base_url}/editora/livros/{publisher_id}/mpage:{page}"
-        logger.info("Fetching publisher books: %s", url)
-        try:
-            response = self.client.get(url)
-            response.raise_for_status()
-            soup = self.parse_html(response.text)
-            books = [parse_book(div, self.base_url) for div in safe_find_all(soup, "div", {"class": "box_livro"})]
-            next_page = bool(safe_find(soup, "div", {"class": "proximo"}))
-            return Pagination(
-                results=books,
-                limit=len(books),
-                page=page,
-                total=len(books),
-                has_next_page=next_page,
-            )
-        except (AttributeError, TypeError, ValueError) as exc:  # pragma: no cover - defensive
-            logger.error("Failed to parse publisher books: %s", exc, exc_info=True)
-            raise ParsingError("Failed to parse publisher books.") from exc
-        except Exception as exc:  # pragma: no cover - unexpected
-            logger.error(
-                "An unexpected error occurred while parsing publisher books: %s",
-                exc,
-                exc_info=True,
-            )
-            raise ParsingError("An unexpected error occurred while parsing publisher books.") from exc
+        """Retrieve books published by a publisher."""
+        return run_sync(self._get_books(publisher_id, page))
 
 
-class AsyncPublisherService(AsyncBaseSkoobService):  # pragma: no cover - thin async wrapper
+class AsyncPublisherService(_PublisherServiceMixin, AsyncBaseSkoobService):  # pragma: no cover - thin async wrapper
     """Asynchronous variant of :class:`PublisherService`."""
 
     def __init__(self, client: AsyncHTTPClient):
         super().__init__(client)
 
     async def get_by_id(self, publisher_id: int) -> Publisher:
-        """Retrieve detailed information about a publisher.
-
-        Parameters
-        ----------
-        publisher_id : int
-            The identifier of the publisher on Skoob.
-
-        Returns
-        -------
-        Publisher
-            Structured publisher information including stats and releases.
-        """
-
-        url = f"{self.base_url}/editora/{publisher_id}"
-        logger.info("Fetching publisher page: %s", url)
-        try:
-            response = await self.client.get(url)
-            response.raise_for_status()
-            soup = self.parse_html(response.text)
-            name = get_tag_text(safe_find(soup, "h2")) or get_tag_text(soup.title)
-            description = get_tag_text(safe_find(soup, "div", {"id": "historico"}))
-            site_link = cast(Tag | None, soup.find("a", string="Site oficial"))
-            website = get_tag_attr(site_link, "href")
-            stats = parse_stats(safe_find(soup, "div", {"id": "vt_estatisticas"}))
-            releases_div = safe_find(soup, "div", {"id": "livros_lancamentos"})
-            releases = [parse_book(div, self.base_url) for div in safe_find_all(releases_div, "div", {"class": "livro-capa-mini"})]
-            return Publisher(
-                id=publisher_id,
-                name=name,
-                description=description,
-                website=website,
-                stats=stats,
-                last_releases=releases,
-            )
-        except (AttributeError, TypeError, ValueError) as exc:  # pragma: no cover - defensive
-            logger.error("Failed to parse publisher page: %s", exc, exc_info=True)
-            raise ParsingError("Failed to parse publisher page.") from exc
-        except Exception as exc:  # pragma: no cover - unexpected
-            logger.error(
-                "An unexpected error occurred while parsing publisher page: %s",
-                exc,
-                exc_info=True,
-            )
-            raise ParsingError("An unexpected error occurred while parsing publisher page.") from exc
+        """Retrieve detailed information about a publisher."""
+        return await self._get_by_id(publisher_id)
 
     async def get_authors(self, publisher_id: int, page: int = 1) -> Pagination[PublisherAuthor]:
-        """Retrieve authors associated with a publisher.
-
-        Parameters
-        ----------
-        publisher_id : int
-            The identifier of the publisher on Skoob.
-        page : int, optional
-            Pagination page, by default ``1``.
-
-        Returns
-        -------
-        Pagination[PublisherAuthor]
-            Paginated list of authors published by the publisher.
-        """
-
-        url = f"{self.base_url}/editora/autores/{publisher_id}/mpage:{page}"
-        logger.info("Fetching publisher authors: %s", url)
-        try:
-            response = await self.client.get(url)
-            response.raise_for_status()
-            soup = self.parse_html(response.text)
-            authors = [parse_author(div, self.base_url) for div in safe_find_all(soup, "div", {"class": "box_autor"})]
-            next_page = bool(safe_find(soup, "div", {"class": "proximo"}))
-            return Pagination(
-                results=authors,
-                limit=len(authors),
-                page=page,
-                total=len(authors),
-                has_next_page=next_page,
-            )
-        except (AttributeError, TypeError, ValueError) as exc:  # pragma: no cover - defensive
-            logger.error("Failed to parse publisher authors: %s", exc, exc_info=True)
-            raise ParsingError("Failed to parse publisher authors.") from exc
-        except Exception as exc:  # pragma: no cover - unexpected
-            logger.error(
-                "An unexpected error occurred while parsing publisher authors: %s",
-                exc,
-                exc_info=True,
-            )
-            raise ParsingError("An unexpected error occurred while parsing publisher authors.") from exc
+        """Retrieve authors associated with a publisher."""
+        return await self._get_authors(publisher_id, page)
 
     async def get_books(self, publisher_id: int, page: int = 1) -> Pagination[PublisherItem]:
-        """Retrieve books published by a given publisher.
-
-        Parameters
-        ----------
-        publisher_id : int
-            The identifier of the publisher on Skoob.
-        page : int, optional
-            Pagination page, by default ``1``.
-
-        Returns
-        -------
-        Pagination[PublisherItem]
-            Paginated list of books released by the publisher.
-        """
-
-        url = f"{self.base_url}/editora/livros/{publisher_id}/mpage:{page}"
-        logger.info("Fetching publisher books: %s", url)
-        try:
-            response = await self.client.get(url)
-            response.raise_for_status()
-            soup = self.parse_html(response.text)
-            books = [parse_book(div, self.base_url) for div in safe_find_all(soup, "div", {"class": "box_livro"})]
-            next_page = bool(safe_find(soup, "div", {"class": "proximo"}))
-            return Pagination(
-                results=books,
-                limit=len(books),
-                page=page,
-                total=len(books),
-                has_next_page=next_page,
-            )
-        except (AttributeError, TypeError, ValueError) as exc:  # pragma: no cover - defensive
-            logger.error("Failed to parse publisher books: %s", exc, exc_info=True)
-            raise ParsingError("Failed to parse publisher books.") from exc
-        except Exception as exc:  # pragma: no cover - unexpected
-            logger.error(
-                "An unexpected error occurred while parsing publisher books: %s",
-                exc,
-                exc_info=True,
-            )
-            raise ParsingError("An unexpected error occurred while parsing publisher books.") from exc
+        """Retrieve books published by a publisher."""
+        return await self._get_books(publisher_id, page)

--- a/pyskoob/users.py
+++ b/pyskoob/users.py
@@ -1,8 +1,12 @@
 """Services for retrieving and manipulating Skoob user data."""
 
+from __future__ import annotations
+
 import logging
 import re
+from collections.abc import Callable
 from datetime import datetime
+from typing import Any
 
 from pyskoob.auth import AsyncAuthService, AuthService
 from pyskoob.exceptions import ParsingError
@@ -29,436 +33,24 @@ from pyskoob.utils.skoob_parser_utils import (
     get_book_id_from_url,
     get_user_id_from_url,
 )
+from pyskoob.utils.sync_async import maybe_await, run_sync
 
 logger = logging.getLogger(__name__)
 
 
-class UserService(AuthenticatedService):
-    """Fetch user profiles, books and friends from Skoob."""
+class _UserServiceMixin:
+    """Shared user retrieval logic for sync and async services."""
 
-    def __init__(self, client: SyncHTTPClient, auth_service: AuthService):
-        """Initialize the service with dependencies.
+    client: Any
+    base_url: str
+    parse_html: Callable[[str], Any]
+    _validate_login: Callable[[], Any]
 
-        The service depends on :class:`AuthService` to validate the current
-        session before performing operations that require authentication such
-        as retrieving your own profile or editing bookshelf information.
-
-        Parameters
-        ----------
-        client : SyncHTTPClient
-            The HTTP client to use for requests.
-        auth_service : AuthService
-            The authentication service.
-        """
-        super().__init__(client, auth_service)
-
-    def get_by_id(self, user_id: int) -> User:
-        """
-        Retrieves a user by their ID.
-
-        Parameters
-        ----------
-        user_id : int
-            The ID of the user.
-
-        Returns
-        -------
-        User
-            The user's information.
-
-        Raises
-        ------
-        FileNotFoundError
-            If the user with the given ID is not found.
-
-        Examples
-        --------
-        >>> service.get_by_id(1).name
-        'Example'
-        """
-        self._validate_login()
+    async def _get_by_id(self, user_id: int) -> User:
+        await maybe_await(self._validate_login)
         logger.info("Getting user by id: %s", user_id)
         url = f"{self.base_url}/v1/user/{user_id}/stats:true"
-        response = self.client.get(url)
-        response.raise_for_status()
-
-        json_data = response.json()
-        if not json_data.get("success"):
-            logger.warning("User with ID %s not found.", user_id)
-            raise FileNotFoundError(f"User with ID {user_id} not found.")
-
-        user_data = json_data["response"]
-        user_data["profile_url"] = self.base_url + user_data["url"]  # patch field for alias
-        user = User.model_validate(user_data)
-        logger.info("Successfully retrieved user: '%s'", user.name)
-        return user
-
-    def get_relations(self, user_id: int, relation: UsersRelation, page: int = 1) -> Pagination[int]:
-        """
-        Retrieves a user's relations (friends, followers, following).
-
-        Parameters
-        ----------
-        user_id : int
-            The ID of the user.
-        relation : UsersRelation
-            The type of relation to retrieve.
-        page : int, optional
-            The page number for pagination, by default 1.
-
-        Returns
-        -------
-        Pagination[int]
-            A paginated list of user IDs.
-
-        Raises
-        ------
-        ParsingError
-            If the HTML structure of the page changes and parsing fails.
-
-        Examples
-        --------
-        >>> service.get_relations(1, UsersRelation.FRIENDS).results
-        [2, 3]
-        """
-        self._validate_login()
-        url = f"{self.base_url}/{relation.value}/listar/{user_id}/page:{page}/limit:100"
-        logger.info("Getting '%s' for user_id: %s, page: %s", relation.value, user_id, page)
-        response = self.client.get(url)
-        response.raise_for_status()
-
-        soup = self.parse_html(response.text)
-        try:
-            users_html = safe_find_all(soup, "div", {"class": "usuarios-mini-lista-txt"})
-            users_id = [int(get_user_id_from_url(get_tag_attr(i.a, "href"))) for i in users_html if i.find("a") and getattr(i, "a", None)]
-            next_page_link = safe_find(soup, "div", {"class": "proximo"})
-        except (AttributeError, ValueError, IndexError) as e:  # pragma: no cover - defensive
-            logger.exception("Failed to parse user relations: %s", e)
-            raise ParsingError("Failed to parse user relations.") from e
-
-        logger.info("Found %s users on page %s.", len(users_id), page)
-        return Pagination(
-            results=users_id,
-            limit=100,
-            page=page,
-            total=len(users_id),  # Placeholder, actual total is not easily available
-            has_next_page=bool(next_page_link),
-        )
-
-    def get_reviews(self, user_id: int, page: int = 1) -> Pagination[BookReview]:
-        """
-        Retrieves reviews made by a user.
-
-        Parameters
-        ----------
-        user_id : int
-            The ID of the user.
-        page : int, optional
-            The page number for pagination, by default 1.
-
-        Returns
-        -------
-        Pagination[BookReview]
-            A paginated list of book reviews.
-
-        Raises
-        ------
-        ParsingError
-            If the HTML structure of the page changes and parsing fails.
-        """
-        self._validate_login()
-        url = f"{self.base_url}/estante/resenhas/{user_id}/mpage:{page}/limit:50"
-        logger.info("Getting reviews for user_id: %s, page: %s", user_id, page)
-        response = self.client.get(url)
-        response.raise_for_status()
-
-        user_reviews: list[BookReview] = []
-        soup = self.parse_html(response.text)
-        try:
-            reviews_html = safe_find_all(soup, "div", {"id": re.compile(r"resenha\d+")})
-            for review_elem in reviews_html:
-                review_id = int(get_tag_attr(review_elem, "id").replace("resenha", ""))
-                book_anchor = safe_find(review_elem, "a", {"href": re.compile(r".*\d+ed\d+.html")})
-                book_url = get_tag_attr(book_anchor, "href")
-                book_id = int(get_book_id_from_url(book_url))
-                edition_id = int(get_book_edition_id_from_url(book_url))
-                star_rating = safe_find(review_elem, "star-rating")
-                rating = float(get_tag_attr(star_rating, "rate", "0"))
-                comment = safe_find(review_elem, "div", {"id": re.compile(r"resenhac\d+")})
-                date_str = get_tag_text(safe_find(comment, "span"))
-                date = None
-                if date_str:
-                    try:
-                        date = datetime.strptime(date_str, "%d/%m/%Y")
-                    except ValueError:
-                        date = None
-                review_text = ""
-                if comment:
-                    span = safe_find(comment, "span")
-                    if span:
-                        siblings = [get_tag_text(sib) for sib in span.next_siblings if hasattr(sib, "get_text")]
-                        review_text = "\n".join(siblings).strip()
-                user_reviews.append(
-                    BookReview(
-                        review_id=review_id,
-                        book_id=book_id,
-                        edition_id=edition_id,
-                        user_id=user_id,
-                        rating=rating,
-                        review_text=review_text,
-                        reviewed_at=date,
-                    )
-                )
-            next_page_link = safe_find(soup, "a", {"string": " Próxima"})
-        except (AttributeError, ValueError, IndexError) as e:  # pragma: no cover - defensive
-            logger.exception("Failed to parse user reviews: %s", e)
-            raise ParsingError("Failed to parse user reviews.") from e
-
-        logger.info("Found %s reviews on page %s.", len(user_reviews), page)
-        return Pagination(
-            results=user_reviews,
-            limit=50,
-            page=page,
-            total=len(user_reviews),  # Placeholder, actual total is not easily available
-            has_next_page=bool(next_page_link),
-        )
-
-    def get_read_stats(self, user_id: int) -> UserReadStats:
-        """
-        Retrieves reading statistics for a user.
-
-        Parameters
-        ----------
-        user_id : int
-            The ID of the user.
-
-        Returns
-        -------
-        UserReadStats
-            The user's reading statistics.
-        """
-        self._validate_login()
-        logger.info("Getting read stats for user_id: %s", user_id)
-        url = f"{self.base_url}/v1/meta_stats/{user_id}"
-
-        response = self.client.get(url)
-        response.raise_for_status()
-
-        json_data = response.json().get("response", {})
-
-        stats = UserReadStats(
-            user_id=user_id,
-            year=json_data.get("ano"),
-            books_read=json_data.get("lido"),
-            pages_read=json_data.get("paginas_lidas"),
-            total_pages=json_data.get("paginas_total"),
-            percent_complete=json_data.get("percentual_lido"),
-            books_total=json_data.get("total"),
-            reading_speed=json_data.get("velocidade_dia"),
-            ideal_reading_speed=json_data.get("velocidade_ideal"),
-        )
-        logger.info("Successfully retrieved read stats for user_id: %s", user_id)
-        return stats
-
-    def get_bookcase(self, user_id: int, bookcase_option: BookcaseOption, page: int = 1) -> Pagination[UserBook]:
-        """
-        Retrieves a user's bookcase.
-
-        Parameters
-        ----------
-        user_id : int
-            The ID of the user.
-        bookcase_option : BookcaseOption
-            The type of bookcase to retrieve.
-        page : int, optional
-            The page number for pagination, by default 1.
-
-        Returns
-        -------
-        Pagination[UserBook]
-            A paginated list of books in the user's bookcase.
-        """
-        self._validate_login()
-        url = f"{self.base_url}/v1/bookcase/books/{user_id}/shelf_id:{bookcase_option.value}/page:{page}/limit:100"
-        logger.info("Getting bookcase for user_id: %s, option: '%s', page: %s", user_id, bookcase_option.name, page)
-        response = self.client.get(url)
-        response.raise_for_status()
-
-        json_data = response.json()
-        next_page = json_data.get("paging", {}).get("next_page")
-        results = []
-        for r in json_data.get("response", []):
-            edicao = r.get("edicao", {})
-            results.append(
-                UserBook(
-                    user_id=user_id,
-                    book_id=edicao.get("livro_id"),
-                    edition_id=edicao.get("id"),
-                    rating=r.get("ranking"),
-                    is_favorite=r.get("favorito"),
-                    is_wishlist=r.get("desejado"),
-                    is_tradable=r.get("troco"),
-                    is_owned=r.get("tenho"),
-                    is_loaned=r.get("emprestei"),
-                    reading_goal_year=r.get("meta"),
-                    pages_read=r.get("paginas_lidas"),
-                )
-            )
-
-        logger.info("Found %s books on page %s.", len(results), page)
-        return Pagination(
-            limit=100,
-            results=results,
-            total=len(results),  # Placeholder, actual total is not easily available
-            has_next_page=bool(next_page),
-            page=page,
-        )
-
-    def search(
-        self,
-        query: str,
-        gender: UserGender | None = None,
-        state: BrazilianState | None = None,
-        page: int = 1,
-        limit: int = 100,
-    ) -> Pagination[UserSearch]:
-        """Search for users on Skoob.
-
-        Parameters
-        ----------
-        query : str
-            The search query for usernames or names.
-        gender : UserGender, optional
-            Optional gender filter (M/F), by default ``None``.
-        state : BrazilianState, optional
-            Optional state filter (e.g., ``SP``), by default ``None``.
-        page : int, optional
-            Page number to fetch, by default ``1``.
-        limit : int, optional
-            Number of users per page, by default ``100``.
-
-        Returns
-        -------
-        Pagination[UserSearch]
-            A paginated list of users matching the criteria.
-
-        Raises
-        ------
-        ParsingError
-            If the HTML structure is invalid or parsing fails.
-
-        Examples
-        --------
-        >>> service.search("example").page
-        1
-        """
-        self._validate_login()
-
-        url = f"{self.base_url}/usuario/lista/busca:{query}/mpage:{page}/limit:{limit}"
-        if gender:
-            url += f"/sexo:{gender.value}"
-        if state:
-            url += f"/uf:{state.value}"
-
-        response = self.client.get(url)
-        response.raise_for_status()
-
-        soup = self.parse_html(response.text)
-
-        try:
-            user_divs = safe_find_all(
-                soup,
-                "div",
-                attrs={"style": re.compile(r"border: 1px solid #e4e4e4")},
-            )
-            results: list[UserSearch] = []
-
-            for div in user_divs:
-                anchor = safe_find(div, "a", attrs={"href": re.compile(r"^/usuario/\d+-")})
-                if not anchor:
-                    continue  # pragma: no cover - defensive
-
-                href = get_tag_attr(anchor, "href")
-                full_url = f"{self.base_url}{href}"
-                match = re.search(r"/usuario/(\d+)-([\w\.\-]+)", href)
-                if not match:
-                    continue  # pragma: no cover - defensive
-
-                user_id = int(match.group(1))
-                username = match.group(2)
-                name = get_tag_text(anchor)
-
-                logger.debug(
-                    "User ID: %s / Username: %s / Name: %s / URL: %s",
-                    user_id,
-                    username,
-                    name,
-                    full_url,
-                )
-
-                results.append(
-                    UserSearch(
-                        id=user_id,
-                        username=username,
-                        name=name,
-                        url=full_url,
-                    )
-                )
-
-            total_tag = safe_find(soup, "div", {"class": "contador"})
-            total_text = get_tag_text(total_tag)
-            total = int(total_text.split("encontrados")[0].strip()) if "encontrados" in total_text else 0
-
-            next_page = safe_find(soup, "a", {"class": "proximo"})
-            has_next = next_page is not None
-
-            return Pagination[UserSearch](
-                results=results,
-                page=page,
-                total=total,
-                limit=limit,
-                has_next_page=has_next,
-            )
-
-        except Exception as e:  # pragma: no cover - defensive
-            raise ParsingError("Failed to parse user search results.") from e
-
-
-class AsyncUserService(AsyncAuthenticatedService):  # pragma: no cover - thin async wrapper
-    """Asynchronous variant of :class:`UserService`.
-
-    Fetch user profiles, books and friends from Skoob asynchronously.
-
-    The service depends on :class:`AsyncAuthService` to validate the current
-    session before performing operations that require authentication such as
-    retrieving your own profile or editing bookshelf information.
-    """
-
-    def __init__(self, client: AsyncHTTPClient, auth_service: AsyncAuthService):
-        super().__init__(client, auth_service)
-
-    async def get_by_id(self, user_id: int) -> User:
-        """Retrieve a user by their ID asynchronously.
-
-        Parameters
-        ----------
-        user_id : int
-            The ID of the user.
-
-        Returns
-        -------
-        User
-            The user's information.
-
-        Raises
-        ------
-        FileNotFoundError
-            If the user with the given ID is not found.
-        """
-        await self._validate_login()
-        logger.info("Getting user by id: %s", user_id)
-        url = f"{self.base_url}/v1/user/{user_id}/stats:true"
-        response = await self.client.get(url)
+        response = await maybe_await(self.client.get, url)
         response.raise_for_status()
         json_data = response.json()
         if not json_data.get("success"):
@@ -470,39 +62,18 @@ class AsyncUserService(AsyncAuthenticatedService):  # pragma: no cover - thin as
         logger.info("Successfully retrieved user: '%s'", user.name)
         return user
 
-    async def get_relations(self, user_id: int, relation: UsersRelation, page: int = 1) -> Pagination[int]:
-        """Retrieve a user's relations (friends, followers, following).
-
-        Parameters
-        ----------
-        user_id : int
-            The ID of the user.
-        relation : UsersRelation
-            The type of relation to retrieve.
-        page : int, optional
-            The page number for pagination, by default ``1``.
-
-        Returns
-        -------
-        Pagination[int]
-            A paginated list of user IDs.
-
-        Raises
-        ------
-        ParsingError
-            If the HTML structure of the page changes and parsing fails.
-        """
-        await self._validate_login()
+    async def _get_relations(self, user_id: int, relation: UsersRelation, page: int = 1) -> Pagination[int]:
+        await maybe_await(self._validate_login)
         url = f"{self.base_url}/{relation.value}/listar/{user_id}/page:{page}/limit:100"
         logger.info("Getting '%s' for user_id: %s, page: %s", relation.value, user_id, page)
-        response = await self.client.get(url)
+        response = await maybe_await(self.client.get, url)
         response.raise_for_status()
         soup = self.parse_html(response.text)
         try:
             users_html = safe_find_all(soup, "div", {"class": "usuarios-mini-lista-txt"})
             users_id = [int(get_user_id_from_url(get_tag_attr(i.a, "href"))) for i in users_html if i.find("a") and getattr(i, "a", None)]
             next_page_link = safe_find(soup, "div", {"class": "proximo"})
-        except (AttributeError, ValueError, IndexError) as e:
+        except (AttributeError, ValueError, IndexError) as e:  # pragma: no cover - defensive
             logger.exception("Failed to parse user relations: %s", e)
             raise ParsingError("Failed to parse user relations.") from e
         logger.info("Found %s users on page %s.", len(users_id), page)
@@ -510,34 +81,15 @@ class AsyncUserService(AsyncAuthenticatedService):  # pragma: no cover - thin as
             results=users_id,
             limit=100,
             page=page,
-            total=len(users_id),
+            total=len(users_id),  # total for this page only
             has_next_page=bool(next_page_link),
         )
 
-    async def get_reviews(self, user_id: int, page: int = 1) -> Pagination[BookReview]:
-        """Retrieve reviews made by a user.
-
-        Parameters
-        ----------
-        user_id : int
-            The ID of the user.
-        page : int, optional
-            The page number for pagination, by default ``1``.
-
-        Returns
-        -------
-        Pagination[BookReview]
-            A paginated list of book reviews.
-
-        Raises
-        ------
-        ParsingError
-            If the HTML structure of the page changes and parsing fails.
-        """
-        await self._validate_login()
+    async def _get_reviews(self, user_id: int, page: int = 1) -> Pagination[BookReview]:
+        await maybe_await(self._validate_login)
         url = f"{self.base_url}/estante/resenhas/{user_id}/mpage:{page}/limit:50"
         logger.info("Getting reviews for user_id: %s, page: %s", user_id, page)
-        response = await self.client.get(url)
+        response = await maybe_await(self.client.get, url)
         response.raise_for_status()
         user_reviews: list[BookReview] = []
         soup = self.parse_html(response.text)
@@ -577,7 +129,7 @@ class AsyncUserService(AsyncAuthenticatedService):  # pragma: no cover - thin as
                     )
                 )
             next_page_link = safe_find(soup, "a", {"string": " Próxima"})
-        except (AttributeError, ValueError, IndexError) as e:
+        except (AttributeError, ValueError, IndexError) as e:  # pragma: no cover - defensive
             logger.exception("Failed to parse user reviews: %s", e)
             raise ParsingError("Failed to parse user reviews.") from e
         logger.info("Found %s reviews on page %s.", len(user_reviews), page)
@@ -585,27 +137,15 @@ class AsyncUserService(AsyncAuthenticatedService):  # pragma: no cover - thin as
             results=user_reviews,
             limit=50,
             page=page,
-            total=len(user_reviews),
+            total=len(user_reviews),  # total for this page only
             has_next_page=bool(next_page_link),
         )
 
-    async def get_read_stats(self, user_id: int) -> UserReadStats:
-        """Retrieve reading statistics for a user.
-
-        Parameters
-        ----------
-        user_id : int
-            The ID of the user.
-
-        Returns
-        -------
-        UserReadStats
-            The user's reading statistics.
-        """
-        await self._validate_login()
+    async def _get_read_stats(self, user_id: int) -> UserReadStats:
+        await maybe_await(self._validate_login)
         logger.info("Getting read stats for user_id: %s", user_id)
         url = f"{self.base_url}/v1/meta_stats/{user_id}"
-        response = await self.client.get(url)
+        response = await maybe_await(self.client.get, url)
         response.raise_for_status()
         json_data = response.json().get("response", {})
         stats = UserReadStats(
@@ -622,31 +162,20 @@ class AsyncUserService(AsyncAuthenticatedService):  # pragma: no cover - thin as
         logger.info("Successfully retrieved read stats for user_id: %s", user_id)
         return stats
 
-    async def get_bookcase(self, user_id: int, bookcase_option: BookcaseOption, page: int = 1) -> Pagination[UserBook]:
-        """Retrieve a user's bookcase.
-
-        Parameters
-        ----------
-        user_id : int
-            The ID of the user.
-        bookcase_option : BookcaseOption
-            The type of bookcase to retrieve.
-        page : int, optional
-            The page number for pagination, by default ``1``.
-
-        Returns
-        -------
-        Pagination[UserBook]
-            A paginated list of books in the user's bookcase.
-        """
-        await self._validate_login()
+    async def _get_bookcase(self, user_id: int, bookcase_option: BookcaseOption, page: int = 1) -> Pagination[UserBook]:
+        await maybe_await(self._validate_login)
         url = f"{self.base_url}/v1/bookcase/books/{user_id}/shelf_id:{bookcase_option.value}/page:{page}/limit:100"
-        logger.info("Getting bookcase for user_id: %s, option: '%s', page: %s", user_id, bookcase_option.name, page)
-        response = await self.client.get(url)
+        logger.info(
+            "Getting bookcase for user_id: %s, option: '%s', page: %s",
+            user_id,
+            bookcase_option.name,
+            page,
+        )
+        response = await maybe_await(self.client.get, url)
         response.raise_for_status()
         json_data = response.json()
         next_page = json_data.get("paging", {}).get("next_page")
-        results = []
+        results: list[UserBook] = []
         for r in json_data.get("response", []):
             edicao = r.get("edicao", {})
             results.append(
@@ -668,12 +197,12 @@ class AsyncUserService(AsyncAuthenticatedService):  # pragma: no cover - thin as
         return Pagination(
             limit=100,
             results=results,
-            total=len(results),
+            total=len(results),  # total for this page only
             has_next_page=bool(next_page),
             page=page,
         )
 
-    async def search(
+    async def _search(
         self,
         query: str,
         gender: UserGender | None = None,
@@ -681,38 +210,13 @@ class AsyncUserService(AsyncAuthenticatedService):  # pragma: no cover - thin as
         page: int = 1,
         limit: int = 100,
     ) -> Pagination[UserSearch]:
-        """Search for users on Skoob.
-
-        Parameters
-        ----------
-        query : str
-            The search query for usernames or names.
-        gender : UserGender, optional
-            Optional gender filter (M/F), by default ``None``.
-        state : BrazilianState, optional
-            Optional state filter, by default ``None``.
-        page : int, optional
-            Page number to fetch, by default ``1``.
-        limit : int, optional
-            Number of users per page, by default ``100``.
-
-        Returns
-        -------
-        Pagination[UserSearch]
-            A paginated list of users matching the criteria.
-
-        Raises
-        ------
-        ParsingError
-            If the HTML structure is invalid or parsing fails.
-        """
-        await self._validate_login()
+        await maybe_await(self._validate_login)
         url = f"{self.base_url}/usuario/lista/busca:{query}/mpage:{page}/limit:{limit}"
         if gender:
             url += f"/sexo:{gender.value}"
         if state:
             url += f"/uf:{state.value}"
-        response = await self.client.get(url)
+        response = await maybe_await(self.client.get, url)
         response.raise_for_status()
         soup = self.parse_html(response.text)
         try:
@@ -725,12 +229,12 @@ class AsyncUserService(AsyncAuthenticatedService):  # pragma: no cover - thin as
             for div in user_divs:
                 anchor = safe_find(div, "a", attrs={"href": re.compile(r"^/usuario/\d+-")})
                 if not anchor:
-                    continue
+                    continue  # pragma: no cover - defensive
                 href = get_tag_attr(anchor, "href")
                 full_url = f"{self.base_url}{href}"
                 match = re.search(r"/usuario/(\d+)-([\w\.\-]+)", href)
                 if not match:
-                    continue
+                    continue  # pragma: no cover - defensive
                 user_id = int(match.group(1))
                 username = match.group(2)
                 name = get_tag_text(anchor)
@@ -754,5 +258,95 @@ class AsyncUserService(AsyncAuthenticatedService):  # pragma: no cover - thin as
                 limit=limit,
                 has_next_page=has_next,
             )
-        except Exception as e:  # pragma: no cover - unlikely
+        except Exception as e:  # pragma: no cover - defensive
             raise ParsingError("Failed to parse user search results.") from e
+
+
+class UserService(_UserServiceMixin, AuthenticatedService):
+    """Fetch user profiles, books and friends from Skoob."""
+
+    def __init__(self, client: SyncHTTPClient, auth_service: AuthService):
+        """Initialize the service with dependencies."""
+
+        super().__init__(client, auth_service)
+
+    def get_by_id(self, user_id: int) -> User:
+        """Retrieve a user by their ID."""
+
+        return run_sync(self._get_by_id(user_id))
+
+    def get_relations(self, user_id: int, relation: UsersRelation, page: int = 1) -> Pagination[int]:
+        """Retrieve a user's relations."""
+
+        return run_sync(self._get_relations(user_id, relation, page))
+
+    def get_reviews(self, user_id: int, page: int = 1) -> Pagination[BookReview]:
+        """Retrieve reviews made by a user."""
+
+        return run_sync(self._get_reviews(user_id, page))
+
+    def get_read_stats(self, user_id: int) -> UserReadStats:
+        """Retrieve reading statistics for a user."""
+
+        return run_sync(self._get_read_stats(user_id))
+
+    def get_bookcase(self, user_id: int, bookcase_option: BookcaseOption, page: int = 1) -> Pagination[UserBook]:
+        """Retrieve a user's bookcase."""
+
+        return run_sync(self._get_bookcase(user_id, bookcase_option, page))
+
+    def search(
+        self,
+        query: str,
+        gender: UserGender | None = None,
+        state: BrazilianState | None = None,
+        page: int = 1,
+        limit: int = 100,
+    ) -> Pagination[UserSearch]:
+        """Search for users on Skoob."""
+
+        return run_sync(self._search(query, gender, state, page, limit))
+
+
+class AsyncUserService(_UserServiceMixin, AsyncAuthenticatedService):  # pragma: no cover - thin async wrapper
+    """Asynchronous variant of :class:`UserService`."""
+
+    def __init__(self, client: AsyncHTTPClient, auth_service: AsyncAuthService):
+        super().__init__(client, auth_service)
+
+    async def get_by_id(self, user_id: int) -> User:
+        """Retrieve a user by their ID."""
+
+        return await self._get_by_id(user_id)
+
+    async def get_relations(self, user_id: int, relation: UsersRelation, page: int = 1) -> Pagination[int]:
+        """Retrieve a user's relations."""
+
+        return await self._get_relations(user_id, relation, page)
+
+    async def get_reviews(self, user_id: int, page: int = 1) -> Pagination[BookReview]:
+        """Retrieve reviews made by a user."""
+
+        return await self._get_reviews(user_id, page)
+
+    async def get_read_stats(self, user_id: int) -> UserReadStats:
+        """Retrieve reading statistics for a user."""
+
+        return await self._get_read_stats(user_id)
+
+    async def get_bookcase(self, user_id: int, bookcase_option: BookcaseOption, page: int = 1) -> Pagination[UserBook]:
+        """Retrieve a user's bookcase."""
+
+        return await self._get_bookcase(user_id, bookcase_option, page)
+
+    async def search(
+        self,
+        query: str,
+        gender: UserGender | None = None,
+        state: BrazilianState | None = None,
+        page: int = 1,
+        limit: int = 100,
+    ) -> Pagination[UserSearch]:
+        """Search for users on Skoob."""
+
+        return await self._search(query, gender, state, page, limit)

--- a/pyskoob/utils/sync_async.py
+++ b/pyskoob/utils/sync_async.py
@@ -1,0 +1,36 @@
+"""Utilities to bridge synchronous and asynchronous execution.
+
+This module provides helpers to call functions that may be synchronous or
+asynchronous without duplicating logic in service implementations.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import inspect
+from collections.abc import Callable, Coroutine
+from typing import Any, TypeVar
+
+T = TypeVar("T")
+
+
+async def maybe_await(func: Callable[..., Any], *args: Any, **kwargs: Any) -> Any:
+    """Call ``func`` and await the result if it returns an awaitable."""
+    result = func(*args, **kwargs)
+    if inspect.isawaitable(result):
+        return await result
+    return result
+
+
+def run_sync(awaitable: Coroutine[Any, Any, T]) -> T:
+    """Synchronously run a coroutine using ``asyncio.run``.
+
+    Note
+    ----
+    This helper should only be used when no event loop is already running.
+    Calling it from within an active loop will raise :class:`RuntimeError`.
+    For such environments, consider using ``nest_asyncio`` or executing the
+    coroutine in a separate thread.
+    """
+
+    return asyncio.run(awaitable)


### PR DESCRIPTION
## Summary
- consolidate login and user search logic into shared mixins
- remove duplicated sync/async implementations for auth and user services
- adjust auth tests to patch internal coroutine helper
- document profile, book, author, and publisher mixin helpers and clarify run_sync usage
- clarify pagination totals and narrow book search error handling

## Testing
- `ruff format --check .`
- `ruff check .`
- `pre-commit run --all-files`
- `pytest -vv`


------
https://chatgpt.com/codex/tasks/task_e_68920ba9bdbc8329bf48ccd9dd44deb6