### PR TITLE
feat: clarify run_sync behavior when loop active

### DIFF
--- a/pyskoob/utils/sync_async.py
+++ b/pyskoob/utils/sync_async.py
@@ -25,12 +25,26 @@ async def maybe_await(func: Callable[..., Any], *args: Any, **kwargs: Any) -> An
 def run_sync(awaitable: Coroutine[Any, Any, T]) -> T:
     """Synchronously run a coroutine using ``asyncio.run``.
 
-    Note
-    ----
-    This helper should only be used when no event loop is already running.
-    Calling it from within an active loop will raise :class:`RuntimeError`.
-    For such environments, consider using ``nest_asyncio`` or executing the
-    coroutine in a separate thread.
+    Notes
+    -----
+    ``asyncio.run`` raises a generic :class:`RuntimeError` when invoked while
+    an event loop is already running. This helper performs an explicit check so
+    callers receive a descriptive error message instead of the generic one.
+
+    Raises
+    ------
+    RuntimeError
+        If an event loop is currently running. In that case, consider awaiting
+        the coroutine directly or running it in a separate thread.
     """
+
+    try:
+        asyncio.get_running_loop()
+    except RuntimeError:
+        pass
+    else:
+        raise RuntimeError(
+            "run_sync() cannot be called from an active event loop. Use 'await' directly or run the coroutine in a separate thread."
+        )
 
     return asyncio.run(awaitable)

--- a/tests/test_sync_async.py
+++ b/tests/test_sync_async.py
@@ -1,0 +1,24 @@
+import pytest
+
+from pyskoob.utils.sync_async import run_sync
+
+
+@pytest.fixture
+def anyio_backend() -> str:  # noqa: D401 (no docstring for fixture)
+    return "asyncio"
+
+
+async def _returns(value: int) -> int:
+    return value
+
+
+def test_run_sync_runs_coroutine() -> None:
+    assert run_sync(_returns(1)) == 1
+
+
+@pytest.mark.anyio
+async def test_run_sync_errors_when_loop_running(anyio_backend: str) -> None:
+    coro = _returns(1)
+    with pytest.raises(RuntimeError, match=r"run_sync\(\) cannot be called"):
+        run_sync(coro)
+    coro.close()


### PR DESCRIPTION
## Summary
- detect existing event loops before `asyncio.run` and raise a clear error
- add tests covering `run_sync` execution and loop-detection failure

## Testing
- `ruff format --check .`
- `ruff check .`
- `pre-commit run --all-files`
- `pytest -vv`


------
https://chatgpt.com/codex/tasks/task_e_68924e9e594c83299f4fee8c9d59a3f7