### PR TITLE
Add context manager to HttpxSyncClient

### DIFF
--- a/pyskoob/http/httpx.py
+++ b/pyskoob/http/httpx.py
@@ -79,6 +79,39 @@ class HttpxSyncClient(SyncHTTPClient):
     def close(self) -> None:
         self._client.close()
 
+    def __enter__(self) -> HttpxSyncClient:
+        """Enter the context manager.
+
+        Returns
+        -------
+        HttpxSyncClient
+            The initialized client instance.
+        """
+
+        return self
+
+    def __exit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc: BaseException | None,
+        tb: TracebackType | None,
+    ) -> None:
+        """Exit the context manager.
+
+        Ensures the underlying HTTPX client is properly closed.
+
+        Parameters
+        ----------
+        exc_type:
+            Exception type raised within the ``with`` block, if any.
+        exc:
+            The exception instance raised within the block, if any.
+        tb:
+            Traceback information, if an exception occurred.
+        """
+
+        self.close()
+
 
 class HttpxAsyncClient(AsyncHTTPClient):
     """Asynchronous HTTP client built on :class:`httpx.AsyncClient`.

--- a/tests/test_httpx_sync_client.py
+++ b/tests/test_httpx_sync_client.py
@@ -1,0 +1,32 @@
+import httpx
+
+from pyskoob.http.httpx import HttpxSyncClient
+
+
+def test_sync_client_get_post_close() -> None:
+    def handler(request: httpx.Request) -> httpx.Response:
+        if request.method == "GET":
+            return httpx.Response(200, text="g")
+        if request.method == "POST":
+            return httpx.Response(200, text=request.content.decode())
+        return httpx.Response(404)
+
+    transport = httpx.MockTransport(handler)
+    client = HttpxSyncClient(transport=transport)
+    resp = client.get("https://x")
+    assert resp.text == "g"
+    resp2 = client.post("https://x", data="p")
+    assert resp2.text == "p"
+    client.close()
+
+
+def test_sync_client_context_manager_closes() -> None:
+    def handler(request: httpx.Request) -> httpx.Response:  # pragma: no cover - simple handler
+        return httpx.Response(200, text="ok")
+
+    transport = httpx.MockTransport(handler)
+    client = HttpxSyncClient(transport=transport)
+    with client as ctx:
+        resp = ctx.get("https://x")
+        assert resp.text == "ok"
+    assert client._client.is_closed


### PR DESCRIPTION
## Summary
- support `with HttpxSyncClient(...)` by adding `__enter__` and `__exit__`
- cover sync client context-manager behavior with new tests

## Testing
- `pre-commit run --all-files`
- `pytest -vv`


------
https://chatgpt.com/codex/tasks/task_e_68924eb491588329b2613f277bd583ba